### PR TITLE
Non-pickle-based blum archive format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ demo: examples/heart.prg
 	x64 $<
 
 examples/heart.prg: examples/heart.gold
-	python -m jeff65 $<
+	python -m jeff65 compile $<

--- a/doc/blum.rst
+++ b/doc/blum.rst
@@ -332,7 +332,7 @@ in other units.
 +--------+------------------------------+-----------------------------------------------+
 | ``ty`` | `Type Union`_                | The type of the symbol.                       |
 +--------+------------------------------+-----------------------------------------------+
-| ``re`` | Table of unsigned 2-byte     | The relocations required to link the symbol.  |
+| ``re`` | Table of unsigned 16-bit     | The relocations required to link the symbol.  |
 |        | integer and `Re struct`_     |                                               |
 +--------+------------------------------+-----------------------------------------------+
 | ``da`` | `Blob Data`_                 | The data associated with the symbol.          |
@@ -364,11 +364,11 @@ Type Union
 
 A `union layout`_ value containing one of the following:
 
- * `Ph struct`_
- * `Vd struct`_
- * `In struct`_
- * `Rf struct`_
- * `Fn struct`_
+* `Ph struct`_
+* `Vd struct`_
+* `In struct`_
+* `Rf struct`_
+* `Fn struct`_
 
 
 ``Ph`` Struct

--- a/doc/blum.rst
+++ b/doc/blum.rst
@@ -1,0 +1,380 @@
+============================
+ Blum Archive Specification
+============================
+
+This document defines the structure of compiled blum object files output by the
+jeff65 compiler.
+
+To propose a change to this document, create a pull request from a branch with a
+name beginning with ``spec-blum-``, which contains the edits to this document
+relevant to enact the change, and if possible, the necessary alterations to the
+reader and/or writer. (If those changes would be high-effort, open a bug once
+the PR has been accepted.)
+
+.. contents::
+
+
+Conventions
+===========
+
+Where literal strings are used, in the context of file data, they represent a
+sequence of bytes. Non-ASCII bytes are represented using the escape sequence
+``\x##``, where ``##`` is replaced by a hexadecimal byte value. (This is as in
+Python.)
+
+Where bytes are numbered, they are numbered starting from zero, starting from
+the byte closest to the beginning of the file. Thus a four-byte datum would have
+its bytes numbered 0, 1, 2, and 3, in that order.
+
+Data described as "in-band" refers to data stored in the "entry" section of the
+file (see `File Structure`_), while data described as "out-of-band" refers to
+data stored in the "blobs" section of the file.
+
+
+File Format
+===========
+
+Very Primitive Values
+---------------------
+
+Numbers wider than 1 byte are stored in little-endian (LSB-first) format. This
+is for consistency with the 6502 processor, which is itself little-endian on the
+occasions that it uses a value wider than 1 byte. Numbers are fixed-width.
+Negative numbers, where allowed, are stored in two's-complement format.
+
+
+File Structure
+--------------
+
+A blum archive is structured as follows: ::
+
+  +---------------------------------------------+
+  | Header (12 bytes)                           |
+  +---------------------------------------------+
+  | Entry 0 (union of Constant, Symbol)         |
+  :                                             :
+
+  :                                             :
+  | Entry (count - 1)                           |
+  +---------------------------------------------+
+  | Blobs (freeform bytes referenced using      |
+  |        offsets from beginning of file)      |
+  +---------------------------------------------+
+
+The header is as follows: ::
+
+  0    1    2    3    4    5    6    7    8    9   10   11   12
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+  |0x93| 'Blm'        |0x0d|0x0a|0x1a|0x0a| Entry count       |
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+
+The first eight bytes of the header are worth explaining. It is lifted from the
+PNG specification, with the first four bytes changed to appropriate values.
+
+ * The leading byte ``\x93`` has the high-bit set, to detect transmission
+   through non-8-bit-clean channels. [#]_
+ * Bytes 1 through 3, ``Blm``, indicates that this is a blum archive. A mix of
+   capital and lowercase letters are used to detect casefolding.
+ * Bytes 4 and 5, ``\x0d\x0a``, are a DOS line ending. This detects DOS-to-UNIX
+   conversion.
+ * Byte 6, ``\x1a``, causes the DOS *type* command to consider this the end of the
+   file, to avoid spewing garbage into the user's terminal.
+ * Byte 7, ``\x0a``, is a UNIX line ending. This detects UNIX-to-DOS conversion.
+
+Thus, various adulterations of the file may be detected.
+
+Each entry is stored in `union layout`_, with allowed types being a `Cn struct`_
+or a `Sy struct`_. See the appropriate sections for a discussion of the
+particulars of how these objects are arranged.
+
+Entries are contiguous, with the first entry beginning immediately after the
+entry count, and each subsequent entry beginning after the preceding one. There
+must be at least as many entries as specified in the header, though entries
+above and beyond the given number will not be read and will be considered part
+of the blobs section.
+
+The blobs section consists of zero or more bytes, beginning immediately after
+the last entry. This area is used to store entry data out-of-band from the
+entries themselves. In particular, machine code is stored in this area. The
+blobs section has no particular layout. Out-of-band data is indicated using an
+offset from the beginning of the file and a length in bytes, as described in
+`Blob Data`_.
+
+.. [#] 1993 is the year *Jurassic Park* was released, starring Jeff Goldblum as
+       Dr. Ian Malcolm.
+
+
+Primitive Values
+----------------
+
+As mentioned above in `Very Primitive Values`_, integers are stored in
+little-endian two's-complement format.
+
+
+Short String
+~~~~~~~~~~~~
+
+Short strings are stored in-band as a length followed by the string data,
+encoded as zero or more UTF-8 bytes (see `RFC 3629`_), as follows: ::
+
+  0    1    2    3    4    5    ...    n
+  +----+----+----+----+----+-- - - - --+
+  | Length = n        | Data ...       |
+  +----+----+----+----+----+-- - - - --+
+
+The length field is an unsigned 4-byte integer, and its value must match the
+byte length of the encoded string data.
+
+.. _`RFC 3629`: https://tools.ietf.org/html/rfc3629
+
+
+Blob Data
+~~~~~~~~~
+
+Blobs are stored out-of-band, and are restricted in length to 64 KiB (65536
+bytes). The in-band part of a blob consists of an offset from the beginning of
+the archive file, and a length field. ::
+
+  0    1    2    3    4    5    6
+  +----+----+----+----+----+----+
+  | Offset            | Length  |
+  +----+----+----+----+----+----+
+
+The offset is a 4-byte unsigned integer, and the length is a 2-byte unsigned
+integer. The sum of the offset and the length must be less than or equal to the
+size in bytes of the archive.
+
+The offset should point into the blobs section of the archive, though this is
+not strictly necessary. Blobs may overlap, and there may exist ranges in the
+blobs section which are not referred to by any entry.
+
+
+Layouts
+-------
+
+Complex values are structured using one of the layouts below.
+
+
+Array Layout
+~~~~~~~~~~~~
+
+An array allows zero or more values of the same type to be stored together. The
+sizes of the values may not be known in advance, and may vary. ::
+
+  0    1    2    3    4    ...    x    ...    y    ...    z
+  +----+----+----+----+-- - - - --+-- - - - --+-- - - - --+
+  | Count = n         | Value 0   | ...       | Value n-1 |
+  +----+----+----+----+-- - - - --+-- - - - --+-- - - - --+
+
+The count field is an unsigned 4-byte integer. The only way to find the end of
+the array is to parse through all of the objects.
+
+Arrays may contain objects of any type, including other arrays, `struct layout`_
+data, etc.
+
+
+Table Layout
+~~~~~~~~~~~~
+
+A table allows zero or more key-value pairs to be stored together, where all
+keys are the same type and all values are the same type. The sizes of the values
+may not be known in advance, and may vary. ::
+
+  0    1    2    3    4  ...  v    ...    w ... x   ...   y    ...    z
+  +----+----+----+----+-- - --+-- - - - --+- - -+-- - - --+-- - - - --+
+  | Count = n         | Key 0 | Value 0   | ... | Key n-1 | Value n-1 |
+  +----+----+----+----+-- - --+-- - - - --+- - -+-- - - --+-- - - - --+
+
+The count field is an unsigned 4-byte integer. The only way to find the end of
+the table is to parse through all of the objects.
+
+Tables values be objects of any type, including arrays, `struct layout`_ data,
+etc., while key types are limited to `short string`_ and integer.
+
+
+Struct Layout
+~~~~~~~~~~~~~
+
+A struct allows zero or more values of different types to be stored together,
+structured as a series of key-value pairs. The sizes of the values may not be
+known in advance, and may vary. ::
+
+  0    1    2    3    4
+  +----+----+----+----+-
+  | Count = n         |
+  +----+----+----+----+-
+
+   4    5    6    ...    x
+  -+----+----+-- - - - --+-
+   | Key 0   | Value 0   |   ...
+  -+----+----+-- - - - --+-
+
+   y   y+1  y+2   ...    z
+  -+----+----+-- - - - --+
+   | Key n-1 | Value n-1 |
+  -+----+----+-- - - - --+
+
+The count field is an unsigned 4-byte integer. Each key is a 2-byte value, where
+each byte is a lowercase alphanumeric ASCII character. The type of the values,
+and therefore how they must be parsed, are determined by a combination of the
+struct type and the key.
+
+The only way to find the end of the struct is to parse through all of the
+objects. The value fields of a struct may contain objects of any type, including
+other structs.
+
+Note that the type code is *not* part of the struct layout; it is only used as
+part of `union layout`_.
+
+Fields with unrecognized keys are to be ignored. This allows fields to be added
+in the future while keeping backwards-compatibility.
+
+
+Union Layout
+~~~~~~~~~~~~
+
+A union allows one value to be stored with a type indicator associated with it.
+The size of the value is determined by its type. ::
+
+  0    1    2    ...    z
+  +----+----+-- - - - --+
+  | Type    | Value     |
+  +----+----+-- - - - --+
+
+The type field is a 2-byte value, where the first byte is an uppercase
+alphabetical ASCII character and the second byte is a lowercase alphanumeric
+ASCII character. The type of the value, and therefore how it must be parsed, is
+determined by the type code.
+
+The only way to find the end of the union is to parse through the object. The
+value field must be in `struct layout`_ of the given type.
+
+
+Complex Values
+--------------
+
+``Cn`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``Cn`` represents a constant symbol which may
+be re-used in other units.
+
++--------+-----------------+---------------------------+
+| Key    | Type            | Description               |
++========+=================+===========================+
+| ``nm`` | `Short String`_ | The name of the constant. |
++--------+-----------------+---------------------------+
+| ``ty`` | `Type Union`_   | The type of the constant. |
++--------+-----------------+---------------------------+
+| ``vl`` | Raw 8 bytes     | The value of the constant.|
++--------+-----------------+---------------------------+
+
+The ``vl`` key indicates a field of fixed length which is interpreted depending
+on the value of ``ty``.
+
+
+``Sy`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``Sy`` represents a symbol which may be re-used
+in other units.
+
++--------+------------------------------+-----------------------------------------------+
+| Key    | Type                         | Description                                   |
++========+==============================+===============================================+
+| ``nm`` | `Short String`_              | The name of the symbol.                       |
++--------+------------------------------+-----------------------------------------------+
+| ``sc`` | `Short String`_              | The section the symbol should be linked into. |
++--------+------------------------------+-----------------------------------------------+
+| ``ty`` | `Type Union`_                | The type of the symbol.                       |
++--------+------------------------------+-----------------------------------------------+
+| ``re`` | Table of unsigned 2-byte     | The relocations required to link the symbol.  |
+|        | integer and `Re struct`_     |                                               |
++--------+------------------------------+-----------------------------------------------+
+| ``da`` | `Blob Data`_                 | The data associated with the symbol.          |
++--------+------------------------------+-----------------------------------------------+
+
+
+``Re`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``Re`` represents a relocation, i.e. a symbolic
+representation of a memory location which must be resolved by the linker.
+
++--------+------------------------------+--------------------------------------------------+
+| Key    | Type                         | Description                                      |
++========+==============================+==================================================+
+| ``sy`` | `Short String`_              | The name of the symbol to link against.          |
++--------+------------------------------+--------------------------------------------------+
+| ``ic`` | 2-byte signed integer        | The value by which to increment the named        |
+|        |                              | address.                                         |
++--------+------------------------------+--------------------------------------------------+
+| ``by`` | One of 'w', 'h', or 'l'      | The address segment (full, high part, low part). |
++--------+------------------------------+--------------------------------------------------+
+
+
+Type Union
+~~~~~~~~~~
+
+A `union layout`_ value containing one of the following:
+
+ * `Ph struct`_
+ * `Vd struct`_
+ * `In struct`_
+ * `Rf struct`_
+ * `Fn struct`_
+
+
+``Ph`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``Ph`` represents an instance of the "phantom"
+type. It has no fields, so it always serializes as four zero bytes.
+
+
+``Vd`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``Vd`` represents an instance of the "void"
+type. It has no fields, so it always serializes as four zero bytes.
+
+
+``In`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``In`` represents an instance of one of the
+integer types.
+
++--------+------------------------------+--------------------------------------------------+
+| Key    | Type                         | Description                                      |
++========+==============================+==================================================+
+| ``wd`` | 1-byte unsigned integer      | The width, in bytes, of the type.                |
++--------+------------------------------+--------------------------------------------------+
+| ``sg`` | One of 0x00 or 0x01          | 0x01 if the type is signed, 0x00 otherwise.      |
++--------+------------------------------+--------------------------------------------------+
+
+
+``Rf`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``Rf`` represents an instance of a reference type.
+
++--------+------------------------------+--------------------------------------------------+
+| Key    | Type                         | Description                                      |
++========+==============================+==================================================+
+| ``tg`` | `Type Union`_                | The type of the reference target.                |
++--------+------------------------------+--------------------------------------------------+
+
+
+``Fn`` Struct
+~~~~~~~~~~~~~
+
+A `struct layout`_ value of type ``Fn`` represents an instance of a function type.
+
++--------+------------------------------+--------------------------------------------------+
+| Key    | Type                         | Description                                      |
++========+==============================+==================================================+
+| ``rt`` | `Type Union`_                | The return type.                                 |
++--------+------------------------------+--------------------------------------------------+
+| ``as`` | Array of `Type Union`_       | The types of the arguments.                      |
++--------+------------------------------+--------------------------------------------------+

--- a/doc/blum.rst
+++ b/doc/blum.rst
@@ -26,9 +26,42 @@ Where bytes are numbered, they are numbered starting from zero, starting from
 the byte closest to the beginning of the file. Thus a four-byte datum would have
 its bytes numbered 0, 1, 2, and 3, in that order.
 
-Data described as "in-band" refers to data stored in the "entry" section of the
-file (see `File Structure`_), while data described as "out-of-band" refers to
-data stored in the "blobs" section of the file.
+Data described as "in-band" refers to data stored inside the structure being
+discussed, while data described as "out-of-band" refers to data stored in some
+other location indicated by an offset.
+
+A box like this represents a single byte: ::
+
+  0    1
+  +----+
+  |    |
+  +----+
+
+The vertical bars will be left out if a multibyte value is being described, but
+the numbers and ``+`` dividers will be used.
+
+A box like this, with ``=`` signs, represents a variable-width field: ::
+
+  0    ...    n
+  +===========+
+  |           |
+  +===========+
+
+The above diagram describes a field which is *n* bytes long. If *n* is negative,
+then the absolute value is used; negative length values, where allowed, indicate
+that the data in the field is zlib-compressed. Note that the length refers to
+the length of the *compressed* data, not the uncompressed data.
+
+A dotted box indicates that an unknown number of fields have been omitted: ::
+
+  0    ...    y    ...    z
+  +-- - - - --+== = = = ==+
+  |           |           |
+  +-- - - - --+== = = = ==+
+
+A dotted line of ``-`` indicates that the omitted fields are of known size,
+while a dotted line of ``=`` indicates that the omitted fields are of unknown
+size.
 
 
 File Format
@@ -43,62 +76,89 @@ occasions that it uses a value wider than 1 byte. Numbers are fixed-width.
 Negative numbers, where allowed, are stored in two's-complement format.
 
 
-File Structure
---------------
+Basic File Structure
+--------------------
 
-A blum archive is structured as follows: ::
+All offsets are bytes from the beginning of the file. Offsets and lengths are
+unsigned 32-bit integers unless otherwise stated. Offsets must be less than the
+length of the file.
 
-  +---------------------------------------------+
-  | Header (12 bytes)                           |
-  +---------------------------------------------+
-  | Entry 0 (union of Constant, Symbol)         |
-  :                                             :
+All CRC32 values are calculated in a manner consistent with Gzip, Zlib, PKZIP,
+etc. The parser is expected to check these values. If they fail to match,
+parsing should stop immediately.
 
-  :                                             :
-  | Entry (count - 1)                           |
-  +---------------------------------------------+
-  | Blobs (freeform bytes referenced using      |
-  |        offsets from beginning of file)      |
-  +---------------------------------------------+
+Blum archives begin with a 16-byte header section, laid out as follows: ::
 
-The header is as follows: ::
+  0    1    2    3    4    5    6    7    8
+  +----+----+----+----+----+----+----+----+
+  |0x93| 'Blm'        |0x0d|0x0a|0x1a|0x0a|
+  +----+----+----+----+----+----+----+----+
 
-  0    1    2    3    4    5    6    7    8    9   10   11   12
+  8    9   10   11   12   13   14   15   16   17   18   19   20
   +----+----+----+----+----+----+----+----+----+----+----+----+
-  |0x93| 'Blm'        |0x0d|0x0a|0x1a|0x0a| Entry count       |
+  | Entry 0 offset    | Entry 0 Length    | Entry 0 CRC32     |
   +----+----+----+----+----+----+----+----+----+----+----+----+
 
 The first eight bytes of the header are worth explaining. It is lifted from the
 PNG specification, with the first four bytes changed to appropriate values.
 
- * The leading byte ``\x93`` has the high-bit set, to detect transmission
-   through non-8-bit-clean channels. [#]_
- * Bytes 1 through 3, ``Blm``, indicates that this is a blum archive. A mix of
-   capital and lowercase letters are used to detect casefolding.
- * Bytes 4 and 5, ``\x0d\x0a``, are a DOS line ending. This detects DOS-to-UNIX
-   conversion.
- * Byte 6, ``\x1a``, causes the DOS *type* command to consider this the end of the
-   file, to avoid spewing garbage into the user's terminal.
- * Byte 7, ``\x0a``, is a UNIX line ending. This detects UNIX-to-DOS conversion.
+* The leading byte ``\x93`` has the high-bit set, to detect transmission
+  through non-8-bit-clean channels. [#]_
+* Bytes 1 through 3, ``Blm``, indicates that this is a blum archive. A mix of
+  capital and lowercase letters are used to detect casefolding.
+* Bytes 4 and 5, ``\x0d\x0a``, are a DOS line ending. This detects DOS-to-UNIX
+  conversion.
+* Byte 6, ``\x1a``, causes the DOS *type* command to consider this the end of the
+  file, to avoid spewing garbage into the user's terminal.
+* Byte 7, ``\x0a``, is a UNIX line ending. This detects UNIX-to-DOS conversion.
 
 Thus, various adulterations of the file may be detected.
 
-Each entry is stored in `union layout`_, with allowed types being a `Cn struct`_
-or a `Sy struct`_. See the appropriate sections for a discussion of the
-particulars of how these objects are arranged.
+The offset indicates the start of the first entry (entry 0) in bytes starting
+from the beginning of the file, e.g. if it was 16, then the entry would be
+located directly after the header.
 
-Entries are contiguous, with the first entry beginning immediately after the
-entry count, and each subsequent entry beginning after the preceding one. There
-must be at least as many entries as specified in the header, though entries
-above and beyond the given number will not be read and will be considered part
-of the blobs section.
+Except for the header, all data items may be located anywhere in the file in no
+particular order. This allows the writer some flexibility when generating the
+file. In addition, the file may contain data which is not accessible by
+traversing the entry structures. The parser is expected to ignore this data.
 
-The blobs section consists of zero or more bytes, beginning immediately after
-the last entry. This area is used to store entry data out-of-band from the
-entries themselves. In particular, machine code is stored in this area. The
-blobs section has no particular layout. Out-of-band data is indicated using an
-offset from the beginning of the file and a length in bytes, as described in
-`Blob Data`_.
+Entries are laid out as follows: ::
+
+  0    1    2    3    4    5    6    7    8    9   10   11   12
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+  | Data offset       | Data Length       | Data CRC32        |
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+
+  12  13   14   15   16   17   18   19   20   21   22   23   24
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+  | Next entry offset | Next Entry Length | Next entry CRC32  |
+  +----+----+----+----+----+----+----+----+----+----+----+----+
+
+  24  25   26   27   28   ...  28+n
+  +----+----+----+----+===========+
+  | Name length       | Name data |
+  +----+----+----+----+===========+
+
+Entries form a linked list, with each entry pointing to the next entry. The last
+entry should have its "next entry" fields all set to 0.
+
+The data pointed to by the "data offset" field is `union layout`_ data allowing
+only an `Sy struct`_. These contain other nested structures; when calculating
+the CRC32, these are included. In the future, other entry types may be allowed;
+when encountering an unrecognized entry type, the parser should skip it, and
+should not attempt to parse the struct.
+
+The "name length" field is a 32-bit signed integer, but negative values are
+currently reserved for future use. If the parser encounters a negative value, it
+should issue a warning and skip the entry.
+
+Note that entries may include trailing data after the name data field. This is
+allowed, and the data must be included in the CRC32 but not otherwise parsed.
+
+Entry order is not important, and two archive files with the same entries in a
+different order may be considered equivalent. However, when manipulating archive
+files, entry order should be preserved if possible to allow convenient diffing.
 
 .. [#] 1993 is the year *Jurassic Park* was released, starring Jeff Goldblum as
        Dr. Ian Malcolm.
@@ -117,13 +177,20 @@ Short String
 Short strings are stored in-band as a length followed by the string data,
 encoded as zero or more UTF-8 bytes (see `RFC 3629`_), as follows: ::
 
-  0    1    2    3    4    5    ...    n
-  +----+----+----+----+----+-- - - - --+
-  | Length = n        | Data ...       |
-  +----+----+----+----+----+-- - - - --+
+  0    1    2    3    4     ...   4+n
+  +----+----+----+----+=============+
+  | Length = n        | String data |
+  +----+----+----+----+=============+
 
-The length field is an unsigned 4-byte integer, and its value must match the
-byte length of the encoded string data.
+The length field is an signed 4-byte integer, and its value must match the byte
+length of the encoded string data. A negative value indicates that the data is
+zlib-compressed.
+
+Despite being called "short" strings, rather long strings may be stored in this
+structure. It is, however, not recommended. If compression is used, the size of
+the decompressed data must not exceed 2 GiB, i.e. the maximum length allowed for
+uncompressed data. If the parser encounters a string longer than this, then it
+should issue a warning and truncate the string.
 
 .. _`RFC 3629`: https://tools.ietf.org/html/rfc3629
 
@@ -131,22 +198,24 @@ byte length of the encoded string data.
 Blob Data
 ~~~~~~~~~
 
-Blobs are stored out-of-band, and are restricted in length to 64 KiB (65536
-bytes). The in-band part of a blob consists of an offset from the beginning of
-the archive file, and a length field. ::
+Blob data are stored out-of-band, at a file location indicated by a length and
+offset field. ::
 
-  0    1    2    3    4    5    6
-  +----+----+----+----+----+----+
-  | Offset            | Length  |
-  +----+----+----+----+----+----+
+  0   1   2   3   4   5   6   7   8   9  10  11  12
+  +---+---+---+---+---+---+---+---+---+---+---+---+
+  | Offset        | Length        | CRC32         |
+  +---+---+---+---+---+---+---+---+---+---+---+---+
 
-The offset is a 4-byte unsigned integer, and the length is a 2-byte unsigned
+The offset is a 32-bit unsigned integer, and the length is a 32-bit signed
 integer. The sum of the offset and the length must be less than or equal to the
 size in bytes of the archive.
 
-The offset should point into the blobs section of the archive, though this is
-not strictly necessary. Blobs may overlap, and there may exist ranges in the
-blobs section which are not referred to by any entry.
+Negative lengths indicate the use of zlib compression. The CRC32 is calculated
+based on actual file data, i.e. if the data is compressed, the CRC32 is computed
+based off of the compressed data. If compression is used, the size of the
+decompressed data must not exceed 2 GiB, i.e. the maximum length allowed for
+uncompressed data. If the parser encounters a blob longer than this, then it
+should stop parsing the archive with an error.
 
 
 Layouts
@@ -162,11 +231,11 @@ An array allows zero or more values of the same type to be stored together. The
 sizes of the values may not be known in advance, and may vary. ::
 
   0    1    2    3    4    ...    x    ...    y    ...    z
-  +----+----+----+----+-- - - - --+-- - - - --+-- - - - --+
-  | Count = n         | Value 0   | ...       | Value n-1 |
-  +----+----+----+----+-- - - - --+-- - - - --+-- - - - --+
+  +----+----+----+----+===========+== = = = ==+===========+
+  | Count = n         | Value 0   |    ...    | Value n-1 |
+  +----+----+----+----+===========+== = = = ==+===========+
 
-The count field is an unsigned 4-byte integer. The only way to find the end of
+The count field is an unsigned 32-bit integer. The only way to find the end of
 the array is to parse through all of the objects.
 
 Arrays may contain objects of any type, including other arrays, `struct layout`_
@@ -180,16 +249,18 @@ A table allows zero or more key-value pairs to be stored together, where all
 keys are the same type and all values are the same type. The sizes of the values
 may not be known in advance, and may vary. ::
 
-  0    1    2    3    4  ...  v    ...    w ... x   ...   y    ...    z
-  +----+----+----+----+-- - --+-- - - - --+- - -+-- - - --+-- - - - --+
-  | Count = n         | Key 0 | Value 0   | ... | Key n-1 | Value n-1 |
-  +----+----+----+----+-- - --+-- - - - --+- - -+-- - - --+-- - - - --+
+  0   1   2   3   4  ...  v    ...    w ... x   ...   y    ...    z
+  +---+---+---+---+=======+===========+= = =+=========+===========+
+  | Count = n     | Key 0 | Value 0   | ... | Key n-1 | Value n-1 |
+  +---+---+---+---+=======+===========+= = =+=========+===========+
 
-The count field is an unsigned 4-byte integer. The only way to find the end of
+The count field is an unsigned 32-bit integer. The only way to find the end of
 the table is to parse through all of the objects.
 
-Tables values be objects of any type, including arrays, `struct layout`_ data,
+Table values be objects of any type, including arrays, `struct layout`_ data,
 etc., while key types are limited to `short string`_ and integer.
+
+Tables are ordered, and the parser must preserve the order of the table entries.
 
 
 Struct Layout
@@ -199,22 +270,12 @@ A struct allows zero or more values of different types to be stored together,
 structured as a series of key-value pairs. The sizes of the values may not be
 known in advance, and may vary. ::
 
-  0    1    2    3    4
-  +----+----+----+----+-
-  | Count = n         |
-  +----+----+----+----+-
+  0     1     2   3   4   ...   x   ...   y  y+1  y+2    ...    z
+  +-----+-----+---+---+=========+-- - = ==+----+----+===========+
+  | Count = n | Key 0 | Value 0 |   ...   | Key n-1 | Value n-1 |
+  +-----+-----+---+---+=========+-- - = ==+----+----+===========+
 
-   4    5    6    ...    x
-  -+----+----+-- - - - --+-
-   | Key 0   | Value 0   |   ...
-  -+----+----+-- - - - --+-
-
-   y   y+1  y+2   ...    z
-  -+----+----+-- - - - --+
-   | Key n-1 | Value n-1 |
-  -+----+----+-- - - - --+
-
-The count field is an unsigned 4-byte integer. Each key is a 2-byte value, where
+The count field is an unsigned 16-bit integer. Each key is a 2-byte value, where
 each byte is a lowercase alphanumeric ASCII character. The type of the values,
 and therefore how they must be parsed, are determined by a combination of the
 struct type and the key.
@@ -226,20 +287,25 @@ other structs.
 Note that the type code is *not* part of the struct layout; it is only used as
 part of `union layout`_.
 
-Fields with unrecognized keys are to be ignored. This allows fields to be added
-in the future while keeping backwards-compatibility.
+Values with unrecognized keys are to be ignored. This allows keys to be added in
+the future while keeping backwards-compatibility. If a key is repeated, then the
+value provided later in the file should be used.
+
+Structs are unordered. Two structs with the same key-value pairs in a different
+order are considered equivalent. However, software which manipulates archives
+should preserve the order of the key-value pairs if possible.
 
 
 Union Layout
 ~~~~~~~~~~~~
 
-A union allows one value to be stored with a type indicator associated with it.
-The size of the value is determined by its type. ::
+A union allows a single value in struct layout to be stored with a type
+indicator. The size of the value is determined by its type. ::
 
   0    1    2    ...    z
-  +----+----+-- - - - --+
+  +----+----+===========+
   | Type    | Value     |
-  +----+----+-- - - - --+
+  +----+----+===========+
 
 The type field is a 2-byte value, where the first byte is an uppercase
 alphabetical ASCII character and the second byte is a lowercase alphanumeric
@@ -253,26 +319,6 @@ value field must be in `struct layout`_ of the given type.
 Complex Values
 --------------
 
-``Cn`` Struct
-~~~~~~~~~~~~~
-
-A `struct layout`_ value of type ``Cn`` represents a constant symbol which may
-be re-used in other units.
-
-+--------+-----------------+---------------------------+
-| Key    | Type            | Description               |
-+========+=================+===========================+
-| ``nm`` | `Short String`_ | The name of the constant. |
-+--------+-----------------+---------------------------+
-| ``ty`` | `Type Union`_   | The type of the constant. |
-+--------+-----------------+---------------------------+
-| ``vl`` | Raw 8 bytes     | The value of the constant.|
-+--------+-----------------+---------------------------+
-
-The ``vl`` key indicates a field of fixed length which is interpreted depending
-on the value of ``ty``.
-
-
 ``Sy`` Struct
 ~~~~~~~~~~~~~
 
@@ -282,8 +328,6 @@ in other units.
 +--------+------------------------------+-----------------------------------------------+
 | Key    | Type                         | Description                                   |
 +========+==============================+===============================================+
-| ``nm`` | `Short String`_              | The name of the symbol.                       |
-+--------+------------------------------+-----------------------------------------------+
 | ``sc`` | `Short String`_              | The section the symbol should be linked into. |
 +--------+------------------------------+-----------------------------------------------+
 | ``ty`` | `Type Union`_                | The type of the symbol.                       |
@@ -293,6 +337,8 @@ in other units.
 +--------+------------------------------+-----------------------------------------------+
 | ``da`` | `Blob Data`_                 | The data associated with the symbol.          |
 +--------+------------------------------+-----------------------------------------------+
+
+The blob in the ``da`` field may not be larger than 64 KiB.
 
 
 ``Re`` Struct
@@ -306,7 +352,7 @@ representation of a memory location which must be resolved by the linker.
 +========+==============================+==================================================+
 | ``sy`` | `Short String`_              | The name of the symbol to link against.          |
 +--------+------------------------------+--------------------------------------------------+
-| ``ic`` | 2-byte signed integer        | The value by which to increment the named        |
+| ``ic`` | 16-bit signed integer        | The value by which to increment the named        |
 |        |                              | address.                                         |
 +--------+------------------------------+--------------------------------------------------+
 | ``by`` | One of 'w', 'h', or 'l'      | The address segment (full, high part, low part). |

--- a/jeff65/__init__.py
+++ b/jeff65/__init__.py
@@ -16,21 +16,71 @@
 
 import argparse
 import pathlib
+import sys
 from . import gold
 from . import blum
 
 
 def main():
-    arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument("input_file", help="the file to compile")
-    arg_parser.add_argument("-v", "--verbose",
-                            help="show the output of each pass",
-                            dest="verbose", action="store_true", default=False)
-    args = arg_parser.parse_args()
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
 
-    input_file = pathlib.PurePath(args.input_file)
+    compile_parser = subparsers.add_parser(
+        'compile', help="compile one or more files")
+    compile_parser.add_argument('file', help="the file to compile",
+                                type=pathlib.PurePath)
+    compile_parser.add_argument("-v", "--verbose",
+                                help="show the output of each pass",
+                                dest="verbose", action="store_true",
+                                default=False)
+    compile_parser.set_defaults(func=cmd_compile)
 
-    archive = gold.translate(input_file, args.verbose)
-    archive.dumpf(input_file.with_suffix('.blum'))
-    blum.link('{}.main'.format(input_file.stem), archive,
-              input_file.with_suffix('.prg'))
+    objdump_parser = subparsers.add_parser(
+        'objdump', help="list symbols of an object")
+    objdump_parser.add_argument('file', help="the file to examine",
+                                type=pathlib.PurePath)
+    objdump_parser.set_defaults(func=cmd_objdump)
+
+    args = parser.parse_args()
+
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+def cmd_none(args):
+    raise NotImplementedError
+
+
+def cmd_compile(args):
+    archive = gold.translate(args.file, args.verbose)
+    archive.dumpf(args.file.with_suffix('.blum'))
+    blum.link('{}.main'.format(args.file.stem), archive,
+              args.file.with_suffix('.prg'))
+
+
+def cmd_objdump(args):
+    archive = blum.Archive()
+    archive.loadf(args.file)
+
+    print("Unit: '{}'".format(args.file.stem))
+
+    if len(archive.constants) == 0:
+        print("Constants: (none)")
+    else:
+        print("Constants:")
+        for name, constant in archive.constants.items():
+            print("    {}: {}".format(name, constant))
+    print()
+
+    if len(archive.symbols) == 0:
+        print("Symbols: (none)")
+    else:
+        print("Symbols:")
+        for name, symbol in archive.symbols.items():
+            print("    {}: size={}, section={}, type={}".format(
+                name, len(symbol.data), symbol.section, symbol.type_info))
+            for relocation in symbol.relocations:
+                print("      {}".format(relocation))

--- a/jeff65/__init__.py
+++ b/jeff65/__init__.py
@@ -67,14 +67,6 @@ def cmd_objdump(args):
 
     print("Unit: '{}'".format(args.file.stem))
 
-    if len(archive.constants) == 0:
-        print("Constants: (none)")
-    else:
-        print("Constants:")
-        for name, constant in archive.constants.items():
-            print("    {}: {}".format(name, constant))
-    print()
-
     if len(archive.symbols) == 0:
         print("Symbols: (none)")
     else:

--- a/jeff65/blum/__init__.py
+++ b/jeff65/blum/__init__.py
@@ -15,11 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .linker import link
-from .symbol import Archive, Symbol, Constant
+from .symbol import Archive, Symbol, Constant, Relocation
 
 __all__ = [
     'link',
     'Archive',
     'Symbol',
     'Constant',
+    'Relocation',
 ]

--- a/jeff65/blum/__init__.py
+++ b/jeff65/blum/__init__.py
@@ -15,12 +15,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .linker import link
-from .symbol import Archive, Symbol, Constant, Relocation
+from .symbol import Archive, Symbol, Relocation
 
 __all__ = [
     'link',
     'Archive',
     'Symbol',
-    'Constant',
     'Relocation',
 ]

--- a/jeff65/blum/fmt.py
+++ b/jeff65/blum/fmt.py
@@ -1,0 +1,87 @@
+# jeff65 disk format helper functions
+# Copyright (C) 2017  jeff65 maintainers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import struct
+
+
+class Fmt:
+    _bool = 0
+    _u8 = 1
+    _u16 = 2
+    _u32 = 3
+    _i8 = 4
+    _i16 = 5
+    _i32 = 6
+    _str = 7
+    _blob = 8
+    _array = 10
+    _table = 11
+    _struct = 12
+    _union = 13
+
+    bool = (_bool,)  # pay attention to scope!
+    u8 = (_u8,)
+    u16 = (_u16,)
+    u32 = (_u32,)
+    i8 = (_i8,)
+    i16 = (_i16,)
+    i32 = (_i32,)
+    str = (_str,)  # pay attention to scope!
+    blob = (_blob,)
+
+    @staticmethod
+    def make_cc(code):
+        cc, = struct.unpack('<H', code.encode('ascii'))
+        return cc
+
+    @classmethod
+    def array(cls, item):
+        return (cls._array, item)
+
+    @classmethod
+    def table(cls, key, value):
+        return (cls._table, key, value)
+
+    @classmethod
+    def struct(cls, ty):
+        return (cls._struct, ty)
+
+    @classmethod
+    def union(cls, tys):
+        return (cls._union, tys)
+
+    @classmethod
+    def find_blobs(cls, obj):
+        """Find all blobs for an object in traversal (DFS) order."""
+        for name, fmt, _, pack in obj.fields:
+            if not pack:
+                continue
+
+            # internal function so that we can recursively investigate arrays
+            # and tables.
+            def search(fmt, val):
+                if fmt[0] == cls._blob:
+                    yield val
+                elif fmt[0] == cls._array:
+                    for v in val:
+                        yield from search(fmt[1], v)
+                elif fmt[0] == cls._table:
+                    for _, v in val.items():
+                        yield from search(fmt[2], v)
+                elif fmt[0] == cls._struct or fmt[0] == cls._union:
+                    yield from cls.find_blobs(val)
+
+            yield from search(fmt, getattr(obj, name))

--- a/jeff65/blum/image.py
+++ b/jeff65/blum/image.py
@@ -37,10 +37,10 @@ def make_startup_for(main, version):
             0x4c, 0xffff,   # 0x000c 0x080d (BH)   jmp $ffff
         ),
         type_info=types.phantom,
-        relocations=[
+        relocations={
             # Relocation for the address of 'main'
-            (0x000d, symbol.Relocation(main)),
-        ])
+            0x000d: symbol.Relocation(main),
+        })
     return archive
 
 

--- a/jeff65/blum/image.py
+++ b/jeff65/blum/image.py
@@ -16,14 +16,14 @@
 
 import re
 import struct
-from . import symbol
+from . import symbol, types
 
 
 def make_startup_for(main, version):
     archive = symbol.Archive()
     archive.symbols['$startup.__start'] = symbol.Symbol(
-        'startup',
-        struct.pack(
+        section='startup',
+        data=struct.pack(
             # Defines a simple startup header. Note that in theory, we could
             # simply make the target of the SYS instruction be our main
             # function, but our relocation system isn't smart enough for that
@@ -36,6 +36,7 @@ def make_startup_for(main, version):
             0x0000,         # 0x000a 0x080b (H)    BASIC end-of-program
             0x4c, 0xffff,   # 0x000c 0x080d (BH)   jmp $ffff
         ),
+        type_info=types.phantom,
         relocations=[
             # Relocation for the address of 'main'
             (0x000d, symbol.Relocation(main)),

--- a/jeff65/blum/symbol.py
+++ b/jeff65/blum/symbol.py
@@ -16,13 +16,18 @@
 
 import collections
 import collections.abc
+import io
 import mmap
 import struct
+import warnings
+import zlib
+from . import types
+from .fmt import Fmt
 
 
-def make_cc(code):
-    cc, = struct.unpack('<H', code.encode('ascii'))
-    return cc
+MAX_STRING_SIZE = (1 << 31) - 1
+MAX_BLOB_SIZE = (1 << 31) - 1
+ARCHIVE_MAGIC = b'\x93Blm\x0d\x0a\x1a\x0a'
 
 
 class Archive:
@@ -33,7 +38,6 @@ class Archive:
     """
 
     def __init__(self, fileobj=None):
-        self.constants = {}
         self.symbols = {}
         if fileobj:
             self.load(fileobj)
@@ -44,17 +48,15 @@ class Archive:
         Items already present in this archive are retained, and items present
         in both archives are replaced with the item from the other archive.
         """
-        self.constants.update(archive.constants)
         self.symbols.update(archive.symbols)
 
     def load(self, fileobj):
-        reader = ArchiveReader()
-        reader.load(fileobj)
-        self.update(reader.archive)
+        with ArchiveReader(fileobj, closefd=False) as reader:
+            self.update(reader.load())
 
     def dump(self, fileobj):
-        writer = ArchiveWriter()
-        writer.dump(self, fileobj)
+        with ArchiveWriter(fileobj, closefd=False) as writer:
+            writer.dump(self)
 
     def dumpf(self, path):
         with open(path, 'wb') as f:
@@ -75,96 +77,31 @@ class Archive:
                 yield (name, offset, reloc)
 
 
-class Symbol:
-    discriminator = make_cc('Sy')
-    fields = [
-        ('_name', 'str', make_cc('nm'), True),
-        ('section', 'str', make_cc('sc'), True),
-        ('type_info', 'type_info', make_cc('ty'), True),
-        ('relocations', 'table u16 relocation', make_cc('re'), True),
-        ('data', 'blob', make_cc('da'), True),
-    ]
-
-    def __init__(self, section, data, type_info, relocations=None):
-        self.section = section
-        self.data = data
-        self.type_info = type_info
-        self._name = None
-        if relocations is not None:
-            self.relocations = collections.OrderedDict(relocations)
-        else:
-            self.relocations = collections.OrderedDict()
-
-    def validate(self):
-        assert isinstance(self.section, str)
-        assert isinstance(self.data, bytes)
-        assert self.type_info is not None
-        assert isinstance(self.relocations, collections.abc.Mapping)
-
-    @classmethod
-    def _empty(cls):
-        return cls(None, None, None)
-
-
-class Constant:
-    discriminator = make_cc('Cn')
-    fields = [
-        ('_name', 'str', make_cc('nm'), True),
-        ('type_info', 'type_info', make_cc('ty'), True),
-        ('value_bin', '8b', make_cc('vl'), True),
-    ]
-
-    def __init__(self, value, type_info):
-        self.value = value
-        self._value_bin = None
-        self.type_info = type_info
-        self._name = None
-
-    def __repr__(self):
-        return 'Constant({}, {})'.format(self.value, self.type_info)
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, Constant)
-            and self.value == other.value
-            and self.type_info == other.type_info)
-
-    @property
-    def value_bin(self):
-        return self.type_info.encode(self.value)
-
-    @value_bin.setter
-    def value_bin(self, value):
-        self._value_bin = value
-
-    def validate(self):
-        assert self.type_info is not None
-        if self.value is None and self._value_bin is not None:
-            self.value = self.type_info.decode(self._value_bin)
-            self._value_bin = None
-        assert self.value is not None
-        assert self._value_bin is None
-
-    @classmethod
-    def _empty(cls):
-        return cls(None, None)
-
-
 class Relocation:
     full = ord('w')
     hi = ord('h')
     lo = ord('l')
 
     fields = [
-        ('symbol', 'str', make_cc('sy'), True),
-        ('increment', 'u16', make_cc('ic'), True),
-        ('byte', 'u8', make_cc('by'), True),
+        ('symbol', Fmt.str, Fmt.make_cc('sy'), True),
+        ('increment', Fmt.i16, Fmt.make_cc('ic'), True),
+        ('byte', Fmt.u8, Fmt.make_cc('by'), True),
     ]
 
     def __init__(self, symbol, increment=0, byte=None):
         self.symbol = symbol
         self.increment = increment
         self.byte = byte or self.full
+
+    def __eq__(self, other):
+        return (isinstance(other, Relocation)
+                and self.symbol == other.symbol
+                and self.increment == other.increment
+                and self.byte == other.byte)
+
+    def __repr__(self):
+        return 'Relocation({}, increment={}, byte={})'.format(
+            self.symbol, self.increment, repr(self.byte))
 
     def bind(self, symbol):
         if self.symbol is None:
@@ -201,7 +138,41 @@ class Relocation:
         return cls(None)
 
 
-ARCHIVE_HEADER = b'\x93Blm\x0d\x0a\x1a\x0a'
+class Symbol:
+    discriminator = Fmt.make_cc('Sy')
+    _fmt_relocation_table = Fmt.table(Fmt.u16, Fmt.struct(Relocation))
+    fields = [
+        ('section', Fmt.str, Fmt.make_cc('sc'), True),
+        ('type_info', types.fmt_type_info, Fmt.make_cc('ty'), True),
+        ('relocations', _fmt_relocation_table, Fmt.make_cc('re'), True),
+        ('data', Fmt.blob, Fmt.make_cc('da'), True),
+    ]
+
+    def __init__(self, section, data, type_info, relocations=None):
+        self.section = section
+        self.data = data
+        self.type_info = type_info
+        if relocations is not None:
+            self.relocations = collections.OrderedDict(relocations)
+        else:
+            self.relocations = collections.OrderedDict()
+
+    def __eq__(self, other):
+        return (isinstance(other, Symbol)
+                and self.section == other.section
+                and self.data == other.data
+                and self.type_info == other.type_info
+                and self.relocations == other.relocations)
+
+    def validate(self):
+        assert isinstance(self.section, str)
+        assert isinstance(self.data, bytes)
+        assert self.type_info is not None
+        assert isinstance(self.relocations, collections.abc.Mapping)
+
+    @classmethod
+    def _empty(cls):
+        return cls(None, None, None)
 
 
 class ArchiveError(Exception):
@@ -209,187 +180,264 @@ class ArchiveError(Exception):
 
 
 class ArchiveWriter:
-    def __init__(self):
+    def __init__(self, fileobj, closefd=True):
+        self.fileobj = fileobj
+        self.closefd = closefd
         self.handlers = {
-            'str': self.dump_string,
-            'u16': self.dump_fmt('<H'),
-            'u8': self.dump_fmt('<B'),
-            '?': self.dump_fmt('<?'),
-            'relocation': self.dump_struct,
-            'constant': self.dump_struct,
-            'type_info': self.dump_union,
-            'array': self.dump_array,
-            'table': self.dump_table,
-            '8b': self.dump_8b,
-            'blob': self.dump_blob,
+            Fmt._bool: self.dump_fmt('?'),
+            Fmt._u8: self.dump_fmt('B'),
+            Fmt._u16: self.dump_fmt('H'),
+            Fmt._u32: self.dump_fmt('L'),
+            Fmt._i8: self.dump_fmt('b'),
+            Fmt._i16: self.dump_fmt('h'),
+            Fmt._i32: self.dump_fmt('l'),
+            Fmt._str: self.dump_string,
+            Fmt._blob: self.dump_blob,
+            Fmt._array: self.dump_array,
+            Fmt._table: self.dump_table,
+            Fmt._struct: self.dump_struct,
+            Fmt._union: self.dump_union,
         }
-        self.offsets = []
+        self.blob_infos = collections.deque()
+        self.crc = 0
+        self._depth = 0
 
-    def dump(self, archive, fileobj):
-        fileobj.write(ARCHIVE_HEADER)
-        entries = len(archive.constants) + len(archive.symbols)
-        fileobj.write(struct.pack('<L', entries))
-        for name, constant in archive.constants.items():
-            self.dump_constant(fileobj, name, constant)
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def close(self):
+        if self.closefd:
+            self.fileobj.close()
+
+    def _write(self, *datas):
+        offset = self.fileobj.tell()
+        for data in datas:
+            assert len(data) == self.fileobj.write(data)
+            self.crc = zlib.crc32(data, self.crc)
+        return offset
+
+    def dump(self, archive):
+        # write out a placeholder header.
+        self.fileobj.seek(0)
+        self.dump_header(0, 0, 0, placeholder=True)
+
+        entry_offset, entry_len, entry_crc = 0, 0, 0
         for name, symbol in archive.symbols.items():
-            self.dump_symbol(fileobj, name, symbol)
-        fills = []
-        for offset, data in self.offsets:
-            fills.append((offset, fileobj.tell()))
-            assert len(data) == fileobj.write(data)
-        for offset, value in fills:
-            fileobj.seek(offset)
-            assert 4 == fileobj.write(struct.pack('<L', value))
+            # first get the blobs out in traversal order, and write them out.
+            # Keep track of the offsets and checksums.
+            for blob in Fmt.find_blobs(symbol):
+                self.crc = 0
+                blob_offset = self._write(blob)
+                self.blob_infos.append((blob_offset, len(blob), self.crc))
 
-    def dump_constant(self, fileobj, name, obj):
-        obj._name = name
-        self.dump_union(fileobj, obj)
+            # next we emit the structure.
+            self.crc = 0
+            sym_offset = self.dump_union([Symbol], symbol)
+            sym_len = self.fileobj.tell() - sym_offset
+            sym_crc = self.crc
+            assert len(self.blob_infos) == 0  # should have consumed all blobs
 
-    def dump_symbol(self, fileobj, name, obj):
-        obj._name = name
-        self.dump_union(fileobj, obj)
+            # finally, the entry
+            self.crc = 0
+            entry_offset = self.dump_entry(
+                sym_offset, sym_len, sym_crc,
+                entry_offset, entry_len, entry_crc, name)
+            entry_len = self.fileobj.tell() - entry_offset
+            entry_crc = self.crc
 
-    def dump_by_type(self, t, fileobj, obj):
-        ts = t.split()
-        return self.handlers[ts[0]](*ts[1:], fileobj, obj)
+        # replace the header with the real one
+        self.fileobj.seek(0)
+        self.dump_header(entry_offset, entry_len, entry_crc)
 
-    def dump_8b(self, fileobj, bs):
-        assert len(bs) == 8
-        assert len(bs) == fileobj.write(bs)
-        return len(bs)
+    def dump_header(self, next_off, next_len, next_crc, placeholder=False):
+        if placeholder:
+            magic = b'\xff' * len(ARCHIVE_MAGIC)
+        else:
+            magic = ARCHIVE_MAGIC
+        return self._write(struct.pack('<8s3L', magic,
+                                       next_off, next_len, next_crc))
 
-    def dump_string(self, fileobj, data: str) -> int:
-        bin = data.encode('utf8')
-        sz = struct.pack('<L', len(bin))
-        count = len(sz) + len(bin)
-        assert count == fileobj.write(sz + bin)
-        return count
+    def dump_entry(self,
+                   data_off, data_len, data_crc,
+                   next_off, next_len, next_crc,
+                   name):
+        enc_name = name.encode('utf8')
+        fixed_part = struct.pack('<6Ll',
+                                 data_off, data_len, data_crc,
+                                 next_off, next_len, next_crc,
+                                 len(enc_name))
+        return self._write(fixed_part, enc_name)
+
+    def dump_by_type(self, t, obj):
+        return self.handlers[t[0]](*t[1:], obj)
+
+    def dump_string(self, data):
+        enc_data = data.encode('utf8')
+        sz = struct.pack('<l', len(enc_data))
+        return self._write(sz, enc_data)
 
     def dump_fmt(self, fmt):
-        def dump(fileobj, data):
-            val = struct.pack(fmt, data)
-            assert len(val) == fileobj.write(val)
-            return len(val)
-        return dump
+        return lambda data: self._write(struct.pack('<' + fmt, data))
 
-    def dump_struct(self, fileobj, obj):
+    def dump_struct(self, ty, obj):
+        assert type(obj) == ty
         field_count = len([None for _, _, _, pack in obj.fields if pack])
-        assert 2 == fileobj.write(struct.pack('<H', field_count))
-        count = 2
-        for field, t, n, pack in obj.fields:
+        offset = self._write(struct.pack('<H', field_count))
+        for field, t, cc, pack in obj.fields:
             if not pack:
                 continue
-            assert 2 == fileobj.write(struct.pack('<H', n))
-            count += 2
-            count += self.dump_by_type(t, fileobj, getattr(obj, field))
-        return count
+            self._write(struct.pack('<H', cc))
+            self.dump_by_type(t, getattr(obj, field))
+        return offset
 
-    def dump_union(self, fileobj, obj):
-        assert 2 == fileobj.write(struct.pack('<H', obj.discriminator))
-        count = self.dump_struct(fileobj, obj)
-        return 2 + count
+    def dump_union(self, tys, obj):
+        assert type(obj) in tys
+        offset = self._write(struct.pack('<H', obj.discriminator))
+        self.dump_struct(type(obj), obj)
+        return offset
 
-    def dump_array(self, t, fileobj, objs):
-        assert 4 == fileobj.write(struct.pack('<L', len(objs)))
-        count = 4
+    def dump_array(self, t, objs):
+        offset = self._write(struct.pack('<L', len(objs)))
         for obj in objs:
-            count += self.dump_by_type(t, fileobj, obj)
-        return count
+            self.dump_by_type(t, obj)
+        return offset
 
-    def dump_table(self, tkey, tvalue, fileobj, table):
-        assert 4 == fileobj.write(struct.pack('<L', len(table)))
-        count = 4
+    def dump_table(self, tkey, tvalue, table):
+        offset = self._write(struct.pack('<L', len(table)))
         for key, value in table.items():
-            count += self.dump_by_type(tkey, fileobj, key)
-            count += self.dump_by_type(tvalue, fileobj, value)
-        return count
+            self.dump_by_type(tkey, key)
+            self.dump_by_type(tvalue, value)
+        return offset
 
-    def dump_blob(self, fileobj, obj):
-        offset = fileobj.tell()
-        assert 6 == fileobj.write(struct.pack('<LH', 0xdeadbeef, len(obj)))
-        self.offsets.append((offset, obj))
-        return 6
+    def dump_blob(self, obj):
+        return self._write(struct.pack('<LLL', *self.blob_infos.popleft()))
 
 
 class ArchiveReader:
-    def __init__(self):
-        from . import types  # avoid circular import
-
+    def __init__(self, fileobj, closefd=True):
+        self.fileobj = fileobj
+        self.closefd = closefd
+        if isinstance(fileobj, io.BytesIO):
+            self._mapping = None
+            self.mmap = fileobj.getbuffer()
+        else:
+            self._mapping = mmap.mmap(self.fileobj.fileno(), 0,
+                                      access=mmap.ACCESS_READ)
+            self.mmap = memoryview(self._mapping)
         self.handlers = {
-            'str': self.load_string,
-            'u16': self.load_fmt('<H'),
-            'u8': self.load_fmt('<B'),
-            '?': self.load_fmt('<?'),
-            'relocation': self.load_struct(Relocation),
-            'constant': self.load_struct(Constant),
-            'type_info': self.load_union(types.known),
-            'array': self.load_array,
-            'table': self.load_table,
-            '8b': self.load_8b,
-            'blob': self.load_blob,
+            Fmt._bool: self.load_fmt('?'),
+            Fmt._u8: self.load_fmt('B'),
+            Fmt._u16: self.load_fmt('H'),
+            Fmt._u32: self.load_fmt('L'),
+            Fmt._i8: self.load_fmt('b'),
+            Fmt._i16: self.load_fmt('h'),
+            Fmt._i32: self.load_fmt('l'),
+            Fmt._str: self.load_string,
+            Fmt._blob: self.load_blob,
+            Fmt._array: self.load_array,
+            Fmt._table: self.load_table,
+            Fmt._struct: self.load_struct,
+            Fmt._union: self.load_union,
         }
-        self.archive = Archive()
 
-    def loadb(self, bs):
-        off = self.verify(bs)
+    def __enter__(self):
+        return self
 
-        off, entries = self.load_fmt('<L', bs, off)
-        for _ in range(entries):
-            off, entry = self.load_entry(bs, off)
-            if isinstance(entry, Constant):
-                self.archive.constants[entry._name] = entry
-            elif isinstance(entry, Symbol):
-                self.archive.symbols[entry._name] = entry
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def close(self):
+        self.mmap.release()
+        self.mmap = None
+        if self._mapping is not None:
+            self._mapping.close()
+            self._mapping = None
+        if self.closefd:
+            self.fileobj.close()
+
+    def load(self):
+        archive = Archive()
+        entry_off, entry_len, entry_crc = self.load_header()
+
+        while entry_off != 0:
+            # load the next entry. This method does its own CRC checking
+            (sym_off, sym_len, sym_crc,
+             entry_off, entry_len, entry_crc,
+             name) = self.load_entry(entry_off, entry_len, entry_crc)
+
+            # load the named symbol
+            assert sym_crc == zlib.crc32(self.mmap[sym_off:sym_off+sym_len])
+            sym_end, symbol = self.load_union([Symbol], sym_off)
+            assert sym_end == sym_off+sym_len
+            archive.symbols[name] = symbol
+
+        return archive
+
+    def load_header(self):
+        magic, entry_off, entry_len, entry_crc = struct.unpack_from(
+            '<8s3L', self.mmap, 0)
+        if magic != ARCHIVE_MAGIC:
+            # Header did not match
+            # TODO attempt to diagnose.
+            raise ArchiveError("File is not a valid blum archive")
+        return entry_off, entry_len, entry_crc
+
+    def load_entry(self, offset, sz, crc):
+        assert crc == zlib.crc32(self.mmap[offset:offset+sz])
+        fmt = '<6Ll'
+        (data_off, data_len, data_crc,
+         next_off, next_len, next_crc,
+         name_len) = struct.unpack_from(fmt, self.mmap, offset)
+        name_start = offset + struct.calcsize(fmt)
+        name_end = name_start + name_len
+        assert name_end <= offset+sz
+        with self.mmap[name_start:name_end] as bview:
+            name = bytes(bview).decode('utf8')
+        return data_off, data_len, data_crc, next_off, next_len, next_crc, name
+
+    def load_by_type(self, t, off):
+        return self.handlers[t[0]](*t[1:], off)
+
+    def load_string(self, off):
+        off, sz = self.load_fmt('l', off)
+        compressed = sz < 0
+        end = off + abs(sz)
+
+        with self.mmap[off:end] as bview:
+            if compressed:
+                dc = zlib.decompressobj()
+                bdata = dc.decompress(bview, max_length=(1 << 31))
+                if len(dc.unconsumed_tail) > 0:
+                    warnings.warn("Truncated large (>2 GiB) string in archive")
             else:
-                raise ArchiveError("Unknown entry type {}".format(type(entry)))
-            entry._name = None
-
-    def load(self, fileobj):
-        with mmap.mmap(fileobj.fileno(), 0, access=mmap.ACCESS_READ) as bs:
-            self.loadb(bs)
-
-    def verify(self, bs):
-        if bs[0:len(ARCHIVE_HEADER)] == ARCHIVE_HEADER:
-            return len(ARCHIVE_HEADER)
-        # Header did not match
-        # TODO attempt to diagnose.
-        raise ArchiveError("File is not a valid blum archive")
-
-    def load_entry(self, bs, off):
-        return self.load_union([Symbol, Constant], bs, off)
-
-    def load_by_type(self, t, bs, off):
-        ts = t.split()
-        return self.handlers[ts[0]](*ts[1:], bs, off)
-
-    def load_8b(self, bs, off):
-        return off+8, bs[off:off+8]
-
-    def load_string(self, bs, off):
-        off, sz = self.load_fmt('<L', bs, off)
-        data = bs[off:off+sz].decode('utf8')
-        return off+sz, data
+                bdata = bytes(bview)
+            return end, bdata.decode('utf8')
 
     def load_fmt(self, fmt, *args):
+        fmt = '<' + fmt
         sz = struct.calcsize(fmt)
 
-        def _load(bs, off):
-            val, = struct.unpack_from(fmt, bs, off)
+        def load_fmt_inner(off):
+            val, = struct.unpack_from(fmt, self.mmap, off)
             return off+sz, val
         if len(args) > 0:
-            return _load(*args)
-        return _load
+            return load_fmt_inner(*args)
+        return load_fmt_inner
 
     def load_struct(self, ty, *args):
-        def _load(bs, off):
+        def load_struct_inner(off):
             field_map = {cc: (field, ft) for field, ft, cc, _ in ty.fields}
-            field_count, = struct.unpack_from('<H', bs, off)
-            off += 2
+            off, field_count = self.load_fmt('H', off)
             obj = ty._empty()
             for _ in range(field_count):
-                cc, = struct.unpack_from('<H', bs, off)
+                off, cc = self.load_fmt('H', off)
                 field, ft = field_map[cc]
-                off, val = self.load_by_type(ft, bs, off+2)
+                off, val = self.load_by_type(ft, off)
                 try:
                     setattr(obj, field, val)
                 except AttributeError as ex:
@@ -398,38 +446,40 @@ class ArchiveReader:
             obj.validate()
             return off, obj
         if len(args) > 0:
-            return _load(*args)
-        return _load
+            return load_struct_inner(*args)
+        return load_struct_inner
 
     def load_union(self, types, *args):
-        def _load(bs, off):
-            disc, = struct.unpack_from('<H', bs, off)
+        def load_union_inner(off):
+            off, disc = self.load_fmt('H', off)
             sel = next(t for t in types if t.discriminator == disc)
-            return self.load_struct(sel, bs, off+2)
+            return self.load_struct(sel, off)
         if len(args) > 0:
-            return _load(*args)
-        return _load
+            return load_union_inner(*args)
+        return load_union_inner
 
-    def load_array(self, t, bs, off):
+    def load_array(self, t, off):
         objs = []
-        sz, = struct.unpack_from('<L', bs, off)
-        off += 4
+        off, sz = self.load_fmt('L', off)
         for _ in range(sz):
-            off, val = self.load_by_type(t, bs, off)
+            off, val = self.load_by_type(t, off)
             objs.append(val)
         return off, objs
 
-    def load_table(self, tkey, tvalue, bs, off):
+    def load_table(self, tkey, tvalue, off):
         table = collections.OrderedDict()
-        sz, = struct.unpack_from('<L', bs, off)
-        off += 4
+        off, sz = self.load_fmt('L', off)
         for _ in range(sz):
-            off, key = self.load_by_type(tkey, bs, off)
-            off, val = self.load_by_type(tvalue, bs, off)
+            off, key = self.load_by_type(tkey, off)
+            off, val = self.load_by_type(tvalue, off)
             table[key] = val
         return off, table
 
-    def load_blob(self, bs, off):
-        blob_off, blob_len = struct.unpack_from('<LH', bs, off)
-        off += struct.calcsize('<LH')
-        return off, bs[blob_off:blob_off+blob_len]
+    def load_blob(self, off):
+        fmt = '<LLL'
+        blob_off, blob_len, blob_crc = struct.unpack_from(
+            fmt, self.mmap, off)
+        off += struct.calcsize(fmt)
+        with self.mmap[blob_off:blob_off+blob_len] as bview:
+            assert blob_crc == zlib.crc32(bview)
+            return off, bytes(bview)

--- a/jeff65/gold/compiler.py
+++ b/jeff65/gold/compiler.py
@@ -71,9 +71,10 @@ def translate(unit, verbose=False):
     for node in obj.children:
         if node.t is 'fun_symbol':
             sym_name = '{}.{}'.format(unit.stem, node.attrs['name'])
-            sym = blum.Symbol('text', node.attrs['text'], attrs={
-                'type': node.attrs['type'],
-            })
+            sym = blum.Symbol(
+                section='text',
+                data=node.attrs['text'],
+                type_info=node.attrs['type'])
             archive.symbols[sym_name] = sym
 
     return archive

--- a/jeff65/gold/compiler.py
+++ b/jeff65/gold/compiler.py
@@ -75,11 +75,5 @@ def translate(unit, verbose=False):
                 'type': node.attrs['type'],
             })
             archive.symbols[sym_name] = sym
-            if 'return_addr' in node.attrs:
-                const_name = '{}/return_addr'.format(sym_name)
-                const_reloc = '{}+{}'.format(sym_name,
-                                             node.attrs['return_addr'])
-                const = blum.Constant(const_reloc, 2)
-                archive.constants[const_name] = const
 
     return archive

--- a/jeff65/gold/mem.py
+++ b/jeff65/gold/mem.py
@@ -14,7 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from . import types, units
+from ..blum import types
+from . import units
 
 
 class MemUnit(units.ExternalUnit):

--- a/jeff65/gold/typepasses.py
+++ b/jeff65/gold/typepasses.py
@@ -56,7 +56,8 @@ class PropagateTypes(binding.ScopedPass):
     def enter_fun(self, node):
         node = node.clone(with_attrs={
             'type': types.FunctionType(
-                node.attrs['return'], *node.attrs['args']),
+                node.attrs['return'] or types.void,
+                *node.attrs['args']),
         })
         del node.attrs['return']
         return super().enter_fun(node)

--- a/jeff65/gold/typepasses.py
+++ b/jeff65/gold/typepasses.py
@@ -14,7 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from . import ast, binding, types
+from ..blum import types
+from . import ast, binding
 
 
 class ConstructTypes(ast.TranslationPass):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-nose==1.3.7
-flake8==3.5.0
-coverage==4.5.1
+nose>=1.3.7
+flake8>=3.5.0
+coverage>=4.5.1
 antlr4-python3-runtime==4.5.2
 coveralls>=1.3.0
+hypothesis>=3.57.0

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,121 @@
+import io
+from nose.tools import (
+    assert_equal)
+from jeff65.blum import symbol, types
+
+
+def pack_by_type(t, obj):
+    writer = symbol.ArchiveWriter()
+    with io.BytesIO() as f:
+        writer.dump_by_type(t, f, obj)
+        return f.getvalue()
+
+
+def pack_constant(name, obj):
+    writer = symbol.ArchiveWriter()
+    with io.BytesIO() as f:
+        writer.dump_constant(f, name, obj)
+        return f.getvalue()
+
+
+def test_pack_string():
+    assert_equal(b'\x05\x00\x00\x00hello', pack_by_type('str', 'hello'))
+
+
+def test_pack_relocation():
+    reloc = symbol.Relocation('spam', 0x42)
+    assert_equal(
+        b'\x03\x00sy\x04\x00\x00\x00spamic\x42\x00byw',
+        pack_by_type('relocation', reloc))
+
+
+def test_pack_type_phantom():
+    assert_equal(b'Ph\x00\x00', pack_by_type('type_info', types.phantom))
+
+
+def test_pack_type_void():
+    assert_equal(b'Vd\x00\x00', pack_by_type('type_info', types.void))
+
+
+def test_pack_types_integral():
+    assert_equal(
+        b'In\x02\x00wd\x01sg\x00',
+        pack_by_type('type_info', types.u8))
+    assert_equal(
+        b'In\x02\x00wd\x02sg\x00',
+        pack_by_type('type_info', types.u16))
+    assert_equal(
+        b'In\x02\x00wd\x03sg\x00',
+        pack_by_type('type_info', types.u24))
+    assert_equal(
+        b'In\x02\x00wd\x04sg\x00',
+        pack_by_type('type_info', types.u32))
+    assert_equal(
+        b'In\x02\x00wd\x01sg\x01',
+        pack_by_type('type_info', types.i8))
+    assert_equal(
+        b'In\x02\x00wd\x02sg\x01',
+        pack_by_type('type_info', types.i16))
+    assert_equal(
+        b'In\x02\x00wd\x03sg\x01',
+        pack_by_type('type_info', types.i24))
+    assert_equal(
+        b'In\x02\x00wd\x04sg\x01',
+        pack_by_type('type_info', types.i32))
+
+
+def test_pack_type_ref():
+    assert_equal(
+        b'Rf\x01\x00tgPh\x00\x00',
+        pack_by_type('type_info', types.ptr))
+    assert_equal(
+        b'Rf\x01\x00tgIn\x02\x00wd\x02sg\x01',
+        pack_by_type('type_info', types.RefType(types.i16)))
+    assert_equal(
+        b'Rf\x01\x00tgRf\x01\x00tgIn\x02\x00wd\x02sg\x01',
+        pack_by_type('type_info', types.RefType(types.RefType(types.i16))))
+
+
+def test_pack_type_fun():
+    assert_equal(
+        b'Fn\x02\x00rtVd\x00\x00as\x00\x00\x00\x00',
+        pack_by_type('type_info', types.FunctionType(types.void)))
+    assert_equal(
+        b'Fn\x02\x00' +
+        b'rtIn\x02\x00wd\x02sg\x00' +
+        b'as\x02\x00\x00\x00' +
+        b'In\x02\x00wd\x01sg\x01' +
+        b'Rf\x01\x00tgIn\x02\x00wd\x03sg\x00',
+        pack_by_type('type_info', types.FunctionType(
+            types.u16, types.i8, types.RefType(types.u24))))
+
+
+def test_pack_constant():
+    assert_equal(
+        b'Cn\x03\x00nm\x04\x00\x00\x00spam' +
+        b'tyIn\x02\x00wd\x01sg\x01' +
+        b'vl\xf9\xff\xff\xff\xff\xff\xff\xff',
+        pack_constant('spam', symbol.Constant(-7, types.i8)))
+    assert_equal(
+        b'Cn\x03\x00nm\x04\x00\x00\x00eggs' +
+        b'tyRf\x01\x00tgIn\x02\x00wd\x03sg\x00' +
+        b'vl\xfe\xca\x00\x00\x00\x00\x00\x00',
+        pack_constant('eggs',
+                      symbol.Constant(0xcafe, types.RefType(types.u24))))
+
+
+def test_pack_symbol():
+    archive = symbol.Archive()
+    archive.symbols['eggs'] = symbol.Symbol('text', b'spam', types.u32)
+    writer = symbol.ArchiveWriter()
+    with io.BytesIO() as f:
+        writer.dump(archive, f)
+        assert_equal(
+            b'\x93Blm\x0d\x0a\x1a\x0a\x01\x00\x00\x00Sy\x05\x00' +
+            b'nm\x04\x00\x00\x00eggs' +
+            b'sc\x04\x00\x00\x00text' +
+            b'tyIn\x02\x00wd\x04sg\x00' +
+            b're\x00\x00\x00\x00' +
+            b'da\x3e\x00\x00\x00\x04\x00' +
+            b'spam',
+            f.getvalue())

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -11,6 +11,12 @@ def pack_by_type(t, obj):
         return f.getvalue()
 
 
+def unpack_by_type(t, bs):
+    reader = symbol.ArchiveReader()
+    _, val = reader.load_by_type(t, bs, 0)
+    return val
+
+
 def pack_constant(name, obj):
     writer = symbol.ArchiveWriter()
     with io.BytesIO() as f:
@@ -18,8 +24,18 @@ def pack_constant(name, obj):
         return f.getvalue()
 
 
+def unpack_entry(bs):
+    reader = symbol.ArchiveReader()
+    _, entry = reader.load_entry(bs, 0)
+    return entry._name, entry
+
+
 def test_pack_string():
     assert_equal(b'\x05\x00\x00\x00hello', pack_by_type('str', 'hello'))
+
+
+def test_unpack_string():
+    assert_equal('hello', unpack_by_type('str', b'\x05\x00\x00\x00hello'))
 
 
 def test_pack_relocation():
@@ -29,12 +45,28 @@ def test_pack_relocation():
         pack_by_type('relocation', reloc))
 
 
+def test_unpack_relocation():
+    reloc = unpack_by_type(
+        'relocation', b'\x03\x00sy\x04\x00\x00\x00spamic\x42\x00byw')
+    assert_equal('spam', reloc.symbol)
+    assert_equal(0x42, reloc.increment)
+    assert_equal(symbol.Relocation.full, reloc.byte)
+
+
 def test_pack_type_phantom():
     assert_equal(b'Ph\x00\x00', pack_by_type('type_info', types.phantom))
 
 
+def test_unpack_type_phantom():
+    assert_equal(types.phantom, unpack_by_type('type_info', b'Ph\x00\x00'))
+
+
 def test_pack_type_void():
     assert_equal(b'Vd\x00\x00', pack_by_type('type_info', types.void))
+
+
+def test_unpack_type_void():
+    assert_equal(types.void, unpack_by_type('type_info', b'Vd\x00\x00'))
 
 
 def test_pack_types_integral():
@@ -64,6 +96,33 @@ def test_pack_types_integral():
         pack_by_type('type_info', types.i32))
 
 
+def test_unpack_types_integral():
+    assert_equal(
+        types.u8,
+        unpack_by_type('type_info', b'In\x02\x00wd\x01sg\x00'))
+    assert_equal(
+        types.u16,
+        unpack_by_type('type_info', b'In\x02\x00wd\x02sg\x00'))
+    assert_equal(
+        types.u24,
+        unpack_by_type('type_info', b'In\x02\x00wd\x03sg\x00'))
+    assert_equal(
+        types.u32,
+        unpack_by_type('type_info', b'In\x02\x00wd\x04sg\x00'))
+    assert_equal(
+        types.i8,
+        unpack_by_type('type_info', b'In\x02\x00wd\x01sg\x01'))
+    assert_equal(
+        types.i16,
+        unpack_by_type('type_info', b'In\x02\x00wd\x02sg\x01'))
+    assert_equal(
+        types.i24,
+        unpack_by_type('type_info', b'In\x02\x00wd\x03sg\x01'))
+    assert_equal(
+        types.i32,
+        unpack_by_type('type_info', b'In\x02\x00wd\x04sg\x01'))
+
+
 def test_pack_type_ref():
     assert_equal(
         b'Rf\x01\x00tgPh\x00\x00',
@@ -74,6 +133,19 @@ def test_pack_type_ref():
     assert_equal(
         b'Rf\x01\x00tgRf\x01\x00tgIn\x02\x00wd\x02sg\x01',
         pack_by_type('type_info', types.RefType(types.RefType(types.i16))))
+
+
+def test_unpack_type_ref():
+    assert_equal(
+        types.ptr,
+        unpack_by_type('type_info', b'Rf\x01\x00tgPh\x00\x00'))
+    assert_equal(
+        types.RefType(types.i16),
+        unpack_by_type('type_info', b'Rf\x01\x00tgIn\x02\x00wd\x02sg\x01'))
+    assert_equal(
+        types.RefType(types.RefType(types.i16)),
+        unpack_by_type('type_info',
+                       b'Rf\x01\x00tgRf\x01\x00tgIn\x02\x00wd\x02sg\x01'))
 
 
 def test_pack_type_fun():
@@ -90,6 +162,22 @@ def test_pack_type_fun():
             types.u16, types.i8, types.RefType(types.u24))))
 
 
+def test_unpack_type_fun():
+    assert_equal(
+        types.FunctionType(types.void),
+        unpack_by_type('type_info',
+                       b'Fn\x02\x00rtVd\x00\x00as\x00\x00\x00\x00'))
+    assert_equal(
+        types.FunctionType(types.u16, types.i8, types.RefType(types.u24)),
+        unpack_by_type(
+            'type_info',
+            b'Fn\x02\x00' +
+            b'rtIn\x02\x00wd\x02sg\x00' +
+            b'as\x02\x00\x00\x00' +
+            b'In\x02\x00wd\x01sg\x01' +
+            b'Rf\x01\x00tgIn\x02\x00wd\x03sg\x00'))
+
+
 def test_pack_constant():
     assert_equal(
         b'Cn\x03\x00nm\x04\x00\x00\x00spam' +
@@ -102,6 +190,21 @@ def test_pack_constant():
         b'vl\xfe\xca\x00\x00\x00\x00\x00\x00',
         pack_constant('eggs',
                       symbol.Constant(0xcafe, types.RefType(types.u24))))
+
+
+def test_unpack_constant():
+    assert_equal(
+        ('spam', symbol.Constant(-7, types.i8)),
+        unpack_entry(
+            b'Cn\x03\x00nm\x04\x00\x00\x00spam' +
+            b'tyIn\x02\x00wd\x01sg\x01' +
+            b'vl\xf9\xff\xff\xff\xff\xff\xff\xff'))
+    assert_equal(
+        ('eggs', symbol.Constant(0xcafe, types.RefType(types.u24))),
+        unpack_entry(
+            b'Cn\x03\x00nm\x04\x00\x00\x00eggs' +
+            b'tyRf\x01\x00tgIn\x02\x00wd\x03sg\x00' +
+            b'vl\xfe\xca\x00\x00\x00\x00\x00\x00'))
 
 
 def test_pack_symbol():
@@ -119,3 +222,21 @@ def test_pack_symbol():
             b'da\x3e\x00\x00\x00\x04\x00' +
             b'spam',
             f.getvalue())
+
+
+def test_unpack_symbol():
+    data = (b'\x93Blm\x0d\x0a\x1a\x0a\x01\x00\x00\x00Sy\x05\x00' +
+            b'nm\x04\x00\x00\x00eggs' +
+            b'sc\x04\x00\x00\x00text' +
+            b'tyIn\x02\x00wd\x04sg\x00' +
+            b're\x00\x00\x00\x00' +
+            b'da\x3e\x00\x00\x00\x04\x00' +
+            b'spam')
+    reader = symbol.ArchiveReader()
+    reader.loadb(data)
+    assert_equal(['eggs'], list(reader.archive.symbols))
+    sym = reader.archive.symbols['eggs']
+    assert_equal('text', sym.section)
+    assert_equal(b'spam', sym.data)
+    assert_equal(types.u32, sym.type_info)
+    assert_equal(0, len(sym.relocations))

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,27 +1,27 @@
 import io
+import struct
+import zlib
+from hypothesis import given
+import hypothesis.strategies as hs
 from nose.tools import (
     assert_equal)
 from jeff65.blum import symbol, types
+from jeff65.blum.fmt import Fmt
 
 
 def pack_by_type(t, obj):
-    writer = symbol.ArchiveWriter()
     with io.BytesIO() as f:
-        writer.dump_by_type(t, f, obj)
-        return f.getvalue()
+        with symbol.ArchiveWriter(f, closefd=False) as writer:
+            writer.dump_by_type(t, obj)
+            return f.getvalue()
 
 
 def unpack_by_type(t, bs):
-    reader = symbol.ArchiveReader()
-    _, val = reader.load_by_type(t, bs, 0)
-    return val
-
-
-def pack_constant(name, obj):
-    writer = symbol.ArchiveWriter()
-    with io.BytesIO() as f:
-        writer.dump_constant(f, name, obj)
-        return f.getvalue()
+    with io.BytesIO(bs) as f:
+        with symbol.ArchiveReader(f, closefd=False) as reader:
+            end, val = reader.load_by_type(t, 0)
+            assert_equal(len(bs), end)
+            return val
 
 
 def unpack_entry(bs):
@@ -30,147 +30,196 @@ def unpack_entry(bs):
     return entry._name, entry
 
 
-def test_pack_string():
-    assert_equal(b'\x05\x00\x00\x00hello', pack_by_type('str', 'hello'))
+def generate_packed_string(s):
+    enc = s.encode('utf8')
+    data = struct.pack('<l', len(enc)) + enc
+    return data
 
 
-def test_unpack_string():
-    assert_equal('hello', unpack_by_type('str', b'\x05\x00\x00\x00hello'))
+@given(hs.text(max_size=symbol.MAX_STRING_SIZE))
+def test_pack_string(s):
+    packed = generate_packed_string(s)
+    assert_equal(packed, pack_by_type(Fmt.str, s))
+
+
+@given(hs.text(max_size=symbol.MAX_STRING_SIZE))
+def test_unpack_uncompressed_string(s):
+    packed = generate_packed_string(s)
+    assert_equal(s, unpack_by_type(Fmt.str, packed))
+
+
+@given(hs.text(max_size=symbol.MAX_STRING_SIZE))
+def test_unpack_compressed_string(s):
+    enc = zlib.compress(s.encode('utf8'))
+    packed = struct.pack('<l', -len(enc)) + enc
+    assert_equal(s, unpack_by_type(Fmt.str, packed))
+
+
+@given(hs.text(max_size=symbol.MAX_STRING_SIZE))
+def test_roundtrip_string(s):
+    packed = pack_by_type(Fmt.str, s)
+    unpacked = unpack_by_type(Fmt.str, packed)
+    assert_equal(s, unpacked)
 
 
 def test_pack_relocation():
     reloc = symbol.Relocation('spam', 0x42)
+    packed = pack_by_type(Fmt.struct(symbol.Relocation), reloc)
     assert_equal(
         b'\x03\x00sy\x04\x00\x00\x00spamic\x42\x00byw',
-        pack_by_type('relocation', reloc))
+        packed)
 
 
 def test_unpack_relocation():
     reloc = unpack_by_type(
-        'relocation', b'\x03\x00sy\x04\x00\x00\x00spamic\x42\x00byw')
+        Fmt.struct(symbol.Relocation),
+        b'\x03\x00sy\x04\x00\x00\x00spamic\x42\x00byw')
     assert_equal('spam', reloc.symbol)
     assert_equal(0x42, reloc.increment)
     assert_equal(symbol.Relocation.full, reloc.byte)
 
 
+@hs.composite
+def relocations(draw):
+    return symbol.Relocation(
+        draw(hs.text(max_size=symbol.MAX_STRING_SIZE)),
+        draw(hs.integers(min_value=-(1 << 15), max_value=(1 << 15)-1)),
+        draw(hs.sampled_from([symbol.Relocation.full,
+                              symbol.Relocation.hi,
+                              symbol.Relocation.lo])))
+
+
+@given(relocations())
+def test_roundtrip_relocation(reloc):
+    t = Fmt.struct(symbol.Relocation)
+    packed = pack_by_type(t, reloc)
+    unpacked = unpack_by_type(t, packed)
+    assert_equal(reloc, unpacked)
+
+
 def test_pack_type_phantom():
-    assert_equal(b'Ph\x00\x00', pack_by_type('type_info', types.phantom))
+    assert_equal(b'Ph\x00\x00',
+                 pack_by_type(types.fmt_type_info, types.phantom))
 
 
 def test_unpack_type_phantom():
-    assert_equal(types.phantom, unpack_by_type('type_info', b'Ph\x00\x00'))
+    assert_equal(types.phantom,
+                 unpack_by_type(types.fmt_type_info, b'Ph\x00\x00'))
 
 
 def test_pack_type_void():
-    assert_equal(b'Vd\x00\x00', pack_by_type('type_info', types.void))
+    assert_equal(b'Vd\x00\x00', pack_by_type(types.fmt_type_info, types.void))
 
 
 def test_unpack_type_void():
-    assert_equal(types.void, unpack_by_type('type_info', b'Vd\x00\x00'))
+    assert_equal(types.void,
+                 unpack_by_type(types.fmt_type_info, b'Vd\x00\x00'))
 
 
 def test_pack_types_integral():
     assert_equal(
         b'In\x02\x00wd\x01sg\x00',
-        pack_by_type('type_info', types.u8))
+        pack_by_type(types.fmt_type_info, types.u8))
     assert_equal(
         b'In\x02\x00wd\x02sg\x00',
-        pack_by_type('type_info', types.u16))
+        pack_by_type(types.fmt_type_info, types.u16))
     assert_equal(
         b'In\x02\x00wd\x03sg\x00',
-        pack_by_type('type_info', types.u24))
+        pack_by_type(types.fmt_type_info, types.u24))
     assert_equal(
         b'In\x02\x00wd\x04sg\x00',
-        pack_by_type('type_info', types.u32))
+        pack_by_type(types.fmt_type_info, types.u32))
     assert_equal(
         b'In\x02\x00wd\x01sg\x01',
-        pack_by_type('type_info', types.i8))
+        pack_by_type(types.fmt_type_info, types.i8))
     assert_equal(
         b'In\x02\x00wd\x02sg\x01',
-        pack_by_type('type_info', types.i16))
+        pack_by_type(types.fmt_type_info, types.i16))
     assert_equal(
         b'In\x02\x00wd\x03sg\x01',
-        pack_by_type('type_info', types.i24))
+        pack_by_type(types.fmt_type_info, types.i24))
     assert_equal(
         b'In\x02\x00wd\x04sg\x01',
-        pack_by_type('type_info', types.i32))
+        pack_by_type(types.fmt_type_info, types.i32))
 
 
 def test_unpack_types_integral():
     assert_equal(
         types.u8,
-        unpack_by_type('type_info', b'In\x02\x00wd\x01sg\x00'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x01sg\x00'))
     assert_equal(
         types.u16,
-        unpack_by_type('type_info', b'In\x02\x00wd\x02sg\x00'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x02sg\x00'))
     assert_equal(
         types.u24,
-        unpack_by_type('type_info', b'In\x02\x00wd\x03sg\x00'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x03sg\x00'))
     assert_equal(
         types.u32,
-        unpack_by_type('type_info', b'In\x02\x00wd\x04sg\x00'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x04sg\x00'))
     assert_equal(
         types.i8,
-        unpack_by_type('type_info', b'In\x02\x00wd\x01sg\x01'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x01sg\x01'))
     assert_equal(
         types.i16,
-        unpack_by_type('type_info', b'In\x02\x00wd\x02sg\x01'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x02sg\x01'))
     assert_equal(
         types.i24,
-        unpack_by_type('type_info', b'In\x02\x00wd\x03sg\x01'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x03sg\x01'))
     assert_equal(
         types.i32,
-        unpack_by_type('type_info', b'In\x02\x00wd\x04sg\x01'))
+        unpack_by_type(types.fmt_type_info, b'In\x02\x00wd\x04sg\x01'))
 
 
 def test_pack_type_ref():
     assert_equal(
         b'Rf\x01\x00tgPh\x00\x00',
-        pack_by_type('type_info', types.ptr))
+        pack_by_type(types.fmt_type_info, types.ptr))
     assert_equal(
         b'Rf\x01\x00tgIn\x02\x00wd\x02sg\x01',
-        pack_by_type('type_info', types.RefType(types.i16)))
+        pack_by_type(types.fmt_type_info, types.RefType(types.i16)))
     assert_equal(
         b'Rf\x01\x00tgRf\x01\x00tgIn\x02\x00wd\x02sg\x01',
-        pack_by_type('type_info', types.RefType(types.RefType(types.i16))))
+        pack_by_type(types.fmt_type_info,
+                     types.RefType(types.RefType(types.i16))))
 
 
 def test_unpack_type_ref():
     assert_equal(
         types.ptr,
-        unpack_by_type('type_info', b'Rf\x01\x00tgPh\x00\x00'))
+        unpack_by_type(types.fmt_type_info, b'Rf\x01\x00tgPh\x00\x00'))
     assert_equal(
         types.RefType(types.i16),
-        unpack_by_type('type_info', b'Rf\x01\x00tgIn\x02\x00wd\x02sg\x01'))
+        unpack_by_type(types.fmt_type_info,
+                       b'Rf\x01\x00tgIn\x02\x00wd\x02sg\x01'))
     assert_equal(
         types.RefType(types.RefType(types.i16)),
-        unpack_by_type('type_info',
+        unpack_by_type(types.fmt_type_info,
                        b'Rf\x01\x00tgRf\x01\x00tgIn\x02\x00wd\x02sg\x01'))
 
 
 def test_pack_type_fun():
     assert_equal(
         b'Fn\x02\x00rtVd\x00\x00as\x00\x00\x00\x00',
-        pack_by_type('type_info', types.FunctionType(types.void)))
+        pack_by_type(types.fmt_type_info, types.FunctionType(types.void)))
     assert_equal(
         b'Fn\x02\x00' +
         b'rtIn\x02\x00wd\x02sg\x00' +
         b'as\x02\x00\x00\x00' +
         b'In\x02\x00wd\x01sg\x01' +
         b'Rf\x01\x00tgIn\x02\x00wd\x03sg\x00',
-        pack_by_type('type_info', types.FunctionType(
+        pack_by_type(types.fmt_type_info, types.FunctionType(
             types.u16, types.i8, types.RefType(types.u24))))
 
 
 def test_unpack_type_fun():
     assert_equal(
         types.FunctionType(types.void),
-        unpack_by_type('type_info',
+        unpack_by_type(types.fmt_type_info,
                        b'Fn\x02\x00rtVd\x00\x00as\x00\x00\x00\x00'))
     assert_equal(
         types.FunctionType(types.u16, types.i8, types.RefType(types.u24)),
         unpack_by_type(
-            'type_info',
+            types.fmt_type_info,
             b'Fn\x02\x00' +
             b'rtIn\x02\x00wd\x02sg\x00' +
             b'as\x02\x00\x00\x00' +
@@ -178,36 +227,85 @@ def test_unpack_type_fun():
             b'Rf\x01\x00tgIn\x02\x00wd\x03sg\x00'))
 
 
-def test_pack_constant():
-    assert_equal(
-        b'Cn\x03\x00nm\x04\x00\x00\x00spam' +
-        b'tyIn\x02\x00wd\x01sg\x01' +
-        b'vl\xf9\xff\xff\xff\xff\xff\xff\xff',
-        pack_constant('spam', symbol.Constant(-7, types.i8)))
-    assert_equal(
-        b'Cn\x03\x00nm\x04\x00\x00\x00eggs' +
-        b'tyRf\x01\x00tgIn\x02\x00wd\x03sg\x00' +
-        b'vl\xfe\xca\x00\x00\x00\x00\x00\x00',
-        pack_constant('eggs',
-                      symbol.Constant(0xcafe, types.RefType(types.u24))))
+@hs.composite
+def type_infos(draw):
+    @hs.composite
+    def integral_types(draw):
+        return types.IntType(
+            draw(hs.integers(min_value=1, max_value=4)),
+            draw(hs.booleans()))
+
+    @hs.composite
+    def ref_types(draw, tys):
+        return types.RefType(draw(tys))
+
+    @hs.composite
+    def fun_types(draw, tys):
+        return types.FunctionType(
+            draw(tys),
+            *draw(hs.lists(tys)))
+
+    return draw(hs.recursive(
+        hs.sampled_from([types.phantom, types.void]) | integral_types(),
+        lambda children: ref_types(children) | fun_types(children)))
 
 
-def test_unpack_constant():
-    assert_equal(
-        ('spam', symbol.Constant(-7, types.i8)),
-        unpack_entry(
-            b'Cn\x03\x00nm\x04\x00\x00\x00spam' +
-            b'tyIn\x02\x00wd\x01sg\x01' +
-            b'vl\xf9\xff\xff\xff\xff\xff\xff\xff'))
-    assert_equal(
-        ('eggs', symbol.Constant(0xcafe, types.RefType(types.u24))),
-        unpack_entry(
-            b'Cn\x03\x00nm\x04\x00\x00\x00eggs' +
-            b'tyRf\x01\x00tgIn\x02\x00wd\x03sg\x00' +
-            b'vl\xfe\xca\x00\x00\x00\x00\x00\x00'))
+@given(type_infos())
+def test_roundtrip_type(ty):
+    packed = pack_by_type(types.fmt_type_info, ty)
+    unpacked = unpack_by_type(types.fmt_type_info, packed)
+    assert_equal(ty, unpacked)
 
 
-def test_pack_symbol():
+simple_archive = (
+    # 0+8: magic
+    b'\x93Blm\x0d\x0a\x1a\x0a' +
+    # 8+c: e0 offset, e0 len, e0 crc
+    b'\x5c\x00\x00\x00\x20\x00\x00\x00\xea\x9c\xfa\xc1' +
+    # 14+4: blob0
+    b'spam' +
+    # 18+4: union+struct info
+    b'Sy\x04\x00' +
+    # 1c+a: Sy.sc field
+    b'sc\x04\x00\x00\x00text' +
+    # 26+c: Sy.ty field w/ In union+struct
+    b'tyIn\x02\x00wd\x04sg\x00' +
+    # 32+a: Sy.re field w/ key and Re struct info
+    b're\x01\x00\x00\x00\xfe\xca\x03\x00'
+    # 3c+b: Re.sy field
+    b'sy\x05\x00\x00\x00beans'
+    # 47+7: Re.ic, Re.by fields
+    b'ic\x07\x00byw' +
+    # 4e+e: Sy.da field
+    b'da\x14\x00\x00\x00\x04\x00\x00\x00\x3d\xff\xda\x43' +
+    # 5c+c: e0 ...
+    b'\x18\x00\x00\x00\x44\x00\x00\x00\x0eu\xf1N' +
+    # 68+c: ... e0 ...
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' +
+    # 74+8: ... e0
+    b'\x04\x00\x00\x00eggs')
+
+
+@hs.composite
+def archives(draw):
+    @hs.composite
+    def symbols(draw):
+        return symbol.Symbol(
+            section=draw(hs.text()),
+            data=draw(hs.binary()),
+            type_info=draw(type_infos()),
+            relocations=draw(hs.dictionaries(
+                hs.integers(min_value=0, max_value=0xffff),
+                relocations())))
+
+    archive = symbol.Archive()
+    archive.symbols = draw(hs.dictionaries(
+        hs.text(),
+        symbols()))
+    return archive
+
+
+def test_pack_archive():
     archive = symbol.Archive()
     archive.symbols['eggs'] = symbol.Symbol(
         section='text',
@@ -216,34 +314,16 @@ def test_pack_symbol():
         relocations={
             0xcafe: symbol.Relocation('beans', 7)
         })
-    writer = symbol.ArchiveWriter()
     with io.BytesIO() as f:
-        writer.dump(archive, f)
-        assert_equal(
-            b'\x93Blm\x0d\x0a\x1a\x0a\x01\x00\x00\x00Sy\x05\x00' +
-            b'nm\x04\x00\x00\x00eggs' +
-            b'sc\x04\x00\x00\x00text' +
-            b'tyIn\x02\x00wd\x04sg\x00' +
-            b're\x01\x00\x00\x00\xfe\xca' +
-            b'\x03\x00sy\x05\x00\x00\x00beansic\x07\x00byw' +
-            b'da\x54\x00\x00\x00\x04\x00' +
-            b'spam',
-            f.getvalue())
+        archive.dump(f)
+        assert_equal(simple_archive, f.getvalue())
 
 
-def test_unpack_symbol():
-    data = (b'\x93Blm\x0d\x0a\x1a\x0a\x01\x00\x00\x00Sy\x05\x00' +
-            b'nm\x04\x00\x00\x00eggs' +
-            b'sc\x04\x00\x00\x00text' +
-            b'tyIn\x02\x00wd\x04sg\x00' +
-            b're\x01\x00\x00\x00\xfe\xca' +
-            b'\x03\x00sy\x05\x00\x00\x00beansic\x07\x00byw' +
-            b'da\x54\x00\x00\x00\x04\x00' +
-            b'spam')
-    reader = symbol.ArchiveReader()
-    reader.loadb(data)
-    assert_equal(['eggs'], list(reader.archive.symbols))
-    sym = reader.archive.symbols['eggs']
+def test_unpack_archive():
+    with io.BytesIO(simple_archive) as f:
+        archive = symbol.Archive(f)
+    assert_equal(['eggs'], list(archive.symbols))
+    sym = archive.symbols['eggs']
     assert_equal('text', sym.section)
     assert_equal(b'spam', sym.data)
     assert_equal(types.u32, sym.type_info)
@@ -252,3 +332,15 @@ def test_unpack_symbol():
     assert_equal('beans', reloc.symbol)
     assert_equal(7, reloc.increment)
     assert_equal(symbol.Relocation.full, reloc.byte)
+
+
+@given(archives())
+def test_roundtrip_archive(a):
+    with io.BytesIO() as f:
+        a.dump(f)
+        packed = f.getvalue()
+
+    with io.BytesIO(packed) as f:
+        unpacked = symbol.Archive(f)
+
+    assert_equal(a.symbols, unpacked.symbols)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -3,7 +3,8 @@ import pathlib
 import sys
 from nose.tools import (
     assert_equal)
-from jeff65.gold import compiler, types
+from jeff65.blum import types
+from jeff65.gold import compiler
 
 sys.stderr = sys.stdout
 
@@ -41,4 +42,4 @@ def test_compile_simple():
     assert_equal('text', sym.section)
     assert_equal(b'\x60', sym.data)
     assert_equal(0, len(sym.relocations))
-    assert_equal(types.FunctionType(None), sym.attrs['type'])
+    assert_equal(types.FunctionType(None), sym.type_info)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -20,7 +20,6 @@ def test_compile_empty():
         raise
 
     assert_equal(0, len(archive.symbols))
-    assert_equal(0, len(archive.constants))
 
 
 def test_compile_simple():
@@ -37,7 +36,6 @@ def test_compile_simple():
         raise
 
     assert_equal(1, len(archive.symbols))
-    assert_equal(0, len(archive.constants))
     sym = archive.symbols['-.main']
     assert_equal('text', sym.section)
     assert_equal(b'\x60', sym.data)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -42,4 +42,4 @@ def test_compile_simple():
     assert_equal('text', sym.section)
     assert_equal(b'\x60', sym.data)
     assert_equal(0, len(sym.relocations))
-    assert_equal(types.FunctionType(None), sym.type_info)
+    assert_equal(types.FunctionType(types.void), sym.type_info)

--- a/tests/test_link_image.py
+++ b/tests/test_link_image.py
@@ -1,7 +1,7 @@
 import io
 from nose.tools import (
     assert_equal)
-from jeff65.blum import image, symbol
+from jeff65.blum import image, symbol, types
 
 
 def link(*archives):
@@ -15,14 +15,16 @@ def link(*archives):
 
 def test_empty_image():
     archive = symbol.Archive()
-    archive.symbols['$startup.__start'] = symbol.Symbol('startup', b'')
+    archive.symbols['$startup.__start'] = symbol.Symbol(
+        'startup', b'', types.phantom)
     _, bs = link(archive)
     assert_equal(bytes([0x01, 0x08]), bs)
 
 
 def test_image_with_startup():
     archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
+    archive.symbols['$test.main'] = symbol.Symbol(
+        'text', b'', types.FunctionType(None))
     _, bs = link(
         image.make_startup_for('$test.main', 0x0001),
         archive)

--- a/tests/test_link_image.py
+++ b/tests/test_link_image.py
@@ -37,84 +37,63 @@ def test_image_with_startup():
 
 
 def test_image_relocation_simple():
-    archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
-    im, _ = link(
-        image.make_startup_for('$test.main', 0x0001),
-        archive)
+    base_address = 0xca00
+    offsets = {'eggs': 0x00fe, 'spam': 0x00ca}
 
-    assert_equal(0x0810, im.compute_relocation('spam', '$test.main'))
-    assert_equal(b'\x10\x08', im.compute_relocation('spam', '$test.main',
-                                                    binary=True))
+    reloc = symbol.Relocation('eggs').bind('spam')
+    assert_equal(0xcafe, reloc.compute_value(base_address, offsets))
+    assert_equal(b'\xfe\xca', reloc.compute_bin(base_address, offsets))
 
 
 def test_image_relocation_forward():
-    archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
-    im, _ = link(
-        image.make_startup_for('$test.main', 0x0001),
-        archive)
+    base_address = 0xca00
+    offsets = {'eggs': 0x00fe, 'spam': 0x00ca}
 
-    assert_equal(0x0815, im.compute_relocation('spam', '$test.main+5'))
-    assert_equal(b'\x15\x08', im.compute_relocation('spam', '$test.main+5',
-                                                    binary=True))
+    reloc = symbol.Relocation('eggs', 2).bind('spam')
+    assert_equal(0xcb00, reloc.compute_value(base_address, offsets))
+    assert_equal(b'\x00\xcb', reloc.compute_bin(base_address, offsets))
 
 
 def test_image_relocation_backward():
-    archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
-    im, _ = link(
-        image.make_startup_for('$test.main', 0x0001),
-        archive)
+    base_address = 0xca00
+    offsets = {'eggs': 0x00fe, 'spam': 0x00ca}
 
-    assert_equal(0x080b, im.compute_relocation('spam', '$test.main-5'))
-    assert_equal(b'\x0b\x08', im.compute_relocation('spam', '$test.main-5',
-                                                    binary=True))
+    reloc = symbol.Relocation('eggs', -2).bind('spam')
+    assert_equal(0xcafc, reloc.compute_value(base_address, offsets))
+    assert_equal(b'\xfc\xca', reloc.compute_bin(base_address, offsets))
 
 
 def test_image_relocation_self():
-    archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
-    im, _ = link(
-        image.make_startup_for('$test.main', 0x0001),
-        archive)
+    base_address = 0xca00
+    offsets = {'eggs': 0x00fe, 'spam': 0x00ca}
 
-    assert_equal(0x0810, im.compute_relocation('$test.main', '.'))
-    assert_equal(b'\x10\x08', im.compute_relocation('$test.main', '.',
-                                                    binary=True))
+    reloc = symbol.Relocation(None).bind('spam')
+    assert_equal(0xcaca, reloc.compute_value(base_address, offsets))
+    assert_equal(b'\xca\xca', reloc.compute_bin(base_address, offsets))
 
 
 def test_image_relocation_lo():
-    archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
-    im, _ = link(
-        image.make_startup_for('$test.main', 0x0001),
-        archive)
+    base_address = 0xca00
+    offsets = {'eggs': 0x00fe, 'spam': 0x00ca}
 
-    assert_equal(0x10, im.compute_relocation('spam', '$test.main,lo'))
-    assert_equal(b'\x10', im.compute_relocation('spam', '$test.main,lo',
-                                                binary=True))
+    reloc = symbol.Relocation('eggs', byte=symbol.Relocation.lo).bind('spam')
+    assert_equal(0xfe, reloc.compute_value(base_address, offsets))
+    assert_equal(b'\xfe', reloc.compute_bin(base_address, offsets))
 
 
 def test_image_relocation_hi():
-    archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
-    im, _ = link(
-        image.make_startup_for('$test.main', 0x0001),
-        archive)
+    base_address = 0xca00
+    offsets = {'eggs': 0x00fe, 'spam': 0x00ca}
 
-    assert_equal(0x08, im.compute_relocation('spam', '$test.main,hi'))
-    assert_equal(b'\x08', im.compute_relocation('spam', '$test.main,hi',
-                                                binary=True))
+    reloc = symbol.Relocation('eggs', byte=symbol.Relocation.hi).bind('spam')
+    assert_equal(0xca, reloc.compute_value(base_address, offsets))
+    assert_equal(b'\xca', reloc.compute_bin(base_address, offsets))
 
 
 def test_image_relocation_complex():
-    archive = symbol.Archive()
-    archive.symbols['$test.main'] = symbol.Symbol('text', b'')
-    im, _ = link(
-        image.make_startup_for('$test.main', 0x0001),
-        archive)
+    base_address = 0xca00
+    offsets = {'eggs': 0x00fe, 'spam': 0x00ca}
 
-    assert_equal(0x15, im.compute_relocation('spam', '$test.main+5,lo'))
-    assert_equal(b'\x15', im.compute_relocation('spam', '$test.main+5,lo',
-                                                binary=True))
+    reloc = symbol.Relocation('eggs', -2, symbol.Relocation.lo).bind('spam')
+    assert_equal(0xfc, reloc.compute_value(base_address, offsets))
+    assert_equal(b'\xfc', reloc.compute_bin(base_address, offsets))

--- a/tests/test_pass_assemble.py
+++ b/tests/test_pass_assemble.py
@@ -3,7 +3,8 @@ from nose.tools import (
     assert_equal,
     assert_false,
     assert_raises)
-from jeff65.gold import asm, ast, storage, types
+from jeff65.blum import types
+from jeff65.gold import asm, ast, storage
 
 sys.stderr = sys.stdout
 


### PR DESCRIPTION
Implements #28 using a custom format described in `doc/blum.rst`.

EDIT: In the cold light of day I've reviewed this and have changes that I want to make.
DOUBLE EDIT: Okay, this should be ready for review now.