### PR TITLE
Simplify transformation visitor pattern impl

### DIFF
--- a/jeff65/gold/ast.py
+++ b/jeff65/gold/ast.py
@@ -49,7 +49,7 @@ class AstNode:
             and self.children == other.children)
 
     def transform(self, transformer):
-        node = getattr(transformer, "enter_{}".format(self.t))(self)
+        node = transformer.transform_enter(self.t, self)
 
         if transformer.transform_attrs and type(node) is AstNode:
             attrs = {}
@@ -78,7 +78,7 @@ class AstNode:
                     node = node.clone()
                 node.children = children
 
-        nodes = getattr(transformer, "exit_{}".format(self.t))(node)
+        nodes = transformer.transform_exit(self.t, node)
 
         if type(nodes) is None:
             nodes = []
@@ -127,18 +127,17 @@ class TranslationPass:
 
     transform_attrs = False
 
+    def transform_enter(self, t, node):
+        return getattr(self, f'enter_{t}', self.__generic_enter)(node)
+
+    def transform_exit(self, t, node):
+        return getattr(self, f'exit_{t}', self.__generic_exit)(node)
+
     def __generic_enter(self, node):
         return node
 
     def __generic_exit(self, node):
         return [node]
-
-    def __getattr__(self, attr):
-        if attr.startswith("enter_"):
-            return self.__generic_enter
-        elif attr.startswith("exit_"):
-            return self.__generic_exit
-        return getattr(object, attr)
 
 
 class AstBuilder(ParseListener):

--- a/jeff65/gold/passes/binding.py
+++ b/jeff65/gold/passes/binding.py
@@ -57,13 +57,22 @@ class ScopedPass(ast.TranslationPass):
             # will be to the same object.
             node = node.clone()
             self.scopes.append(node)
+            node = self.enter__scope(node)
         return node
 
     def transform_exit(self, t, node):
-        node = super().transform_exit(t, node)
+        if t in self.scoped_types:
+            node = self.exit__scope(node)
+        nodes = super().transform_exit(t, node)
         if t in self.scoped_types:
             self.scopes.pop()
+        return nodes
+
+    def enter__scope(self, node):
         return node
+
+    def exit__scope(self, nodes):
+        return nodes
 
 
 @pattern.transform(pattern.Order.Descending)

--- a/jeff65/gold/passes/typepasses.py
+++ b/jeff65/gold/passes/typepasses.py
@@ -61,4 +61,4 @@ class PropagateTypes(binding.ScopedPass):
                 *node.attrs['args']),
         })
         del node.attrs['return']
-        return super().enter_fun(node)
+        return node

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,3 +1,11 @@
+import hypothesis.strategies as st
+from collections import namedtuple
+from hypothesis import assume
+from hypothesis.stateful import (
+    Bundle,
+    RuleBasedStateMachine,
+    rule,
+    precondition)
 from nose.tools import (
     assert_equal)
 from jeff65.blum import types
@@ -10,6 +18,61 @@ def transform(node, xform):
     result = node.transform(xform)
     assert_equal(backup, node)  # check that the previous AST wasn't mutated
     return result
+
+
+Frame = namedtuple('Frame', ['t', 'node', 'orig', 'names'])
+
+
+class ScopedTransform(RuleBasedStateMachine):
+    def __init__(self):
+        super().__init__()
+        self.frames = []
+        self.transform = binding.ScopedPass()
+
+    names = Bundle('names')
+    constants = Bundle('constants')
+
+    @rule(target=names, n=st.text())
+    def n(self, n):
+        return n
+
+    @rule(t=st.sampled_from(binding.ScopedPass.scoped_types))
+    def enter_node(self, t):
+        orig = ast.AstNode(t, None)
+        node = self.transform.transform_enter(t, orig)
+        self.frames.append(Frame(t, node, orig, {}))
+
+    @precondition(lambda self: len(self.frames) > 0)
+    @rule(t=st.sampled_from(binding.ScopedPass.scoped_types))
+    def exit_node(self, t):
+        # this would probably be more efficient if we could use preconditions
+        # somehow?
+        assume(self.frames[-1].t == t)
+        frame = self.frames.pop()
+        node, *nodes = self.transform.transform_exit(t, frame.node)
+        assert len(nodes) == 0
+        assert frame.orig == ast.AstNode(t, None)
+        assert frame.names == node.get_attr_default('known_names', {})
+
+    @precondition(lambda self: len(self.frames) > 0)
+    @rule(n=names, v=st.integers())
+    def bind_name(self, n, v):
+        self.transform.bind_name(n, v)
+        self.frames[-1].names[n] = v
+
+    @precondition(lambda self: len(self.frames) > 0)
+    @rule(n=names)
+    def look_up_name(self, n):
+        try:
+            ev = next(f.names[n]
+                      for f in reversed(self.frames)
+                      if n in f.names)
+        except StopIteration:
+            ev = None
+        assert ev == self.transform.look_up_name(n)
+
+
+TestScopedPass = ScopedTransform.TestCase
 
 
 def test_explicit_scopes_single():


### PR DESCRIPTION
Previously, we'd have `AstNode.transform` dynamically call the `enter_` and
`exit_` methods. Then the pattern system would implement `__getattr__` to
catch all of them, which makes it hard to follow.

Now, `AstNode.transform` calls `transform_enter` and `transform_exit`, and the
base transformer does the dynamic dispatch. The pattern system doesn't
inherit from it, so no dynamic behavior there.

As a side benefit, this also simplified inheriting from `ScopedPass`.